### PR TITLE
feat: Show a single alert with details

### DIFF
--- a/lib/alerts.ex
+++ b/lib/alerts.ex
@@ -10,4 +10,7 @@ defmodule Alerts do
 
   @spec all :: [Alert.t()]
   defdelegate all(), to: AlertsPubSub
+
+  @spec get(Alert.id()) :: {:ok, Alert.t()} | :not_found
+  defdelegate get(id), to: AlertsPubSub
 end

--- a/lib/alerts/alerts_pub_sub.ex
+++ b/lib/alerts/alerts_pub_sub.ex
@@ -42,6 +42,10 @@ defmodule Alerts.AlertsPubSub do
   @spec all(GenServer.server()) :: [Alert.t()]
   def all(server \\ __MODULE__), do: GenServer.call(server, {:all})
 
+  @spec get(Alert.id()) :: {:ok, Alert.t()} | :not_found
+  @spec get(Alert.id(), GenServer.server()) :: {:ok, Alert.t()} | :not_found
+  def get(id, server \\ __MODULE__), do: GenServer.call(server, {:get, id})
+
   # Server
 
   @impl GenServer
@@ -61,6 +65,11 @@ defmodule Alerts.AlertsPubSub do
   @impl GenServer
   def handle_call({:all}, _from, %__MODULE__{store: store} = state) do
     {:reply, Store.all(store), state}
+  end
+
+  @impl GenServer
+  def handle_call({:get, id}, _from, %__MODULE__{store: store} = state) do
+    {:reply, Store.by_id(store, id), state}
   end
 
   @impl GenServer

--- a/lib/alerts_viewer_web.ex
+++ b/lib/alerts_viewer_web.ex
@@ -89,6 +89,7 @@ defmodule AlertsViewerWeb do
       import AlertsViewerWeb.IconComponents
       import AlertsViewerWeb.Gettext
       import AlertsViewerWeb.DateTimeHelpers
+      import AlertsViewerWeb.StringHelpers
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -524,10 +524,21 @@ defmodule AlertsViewerWeb.CoreComponents do
     ~H"""
     <ol>
       <li :for={date_time <- @date_times} class="whitespace-nowrap">
-        <%= friendly_date_time(date_time) %>
+        <.date_time date_time={date_time} />
       </li>
       <li :if={@more}>…</li>
     </ol>
+    """
+  end
+
+  @doc """
+  Renders a date-time using human-friendly formatting.
+  """
+  attr :date_time, :map, required: true
+
+  def date_time(assigns) do
+    ~H"""
+    <%= friendly_date_time(@date_time) %>
     """
   end
 

--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -305,7 +305,7 @@ defmodule AlertsViewerWeb.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-zinc-500 focus:border-zinc-500 sm:text-sm"
+        class="mt-1 block w-full border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-zinc-500 focus:border-zinc-500 sm:text-sm"
         multiple={@multiple}
         {@rest}
       >

--- a/lib/alerts_viewer_web/live/alert_component.ex
+++ b/lib/alerts_viewer_web/live/alert_component.ex
@@ -1,0 +1,62 @@
+defmodule AlertsViewerWeb.AlertComponent do
+  @moduledoc """
+  Component for rendering an Alert with all of its details.
+  """
+
+  use AlertsViewerWeb, :live_component
+
+  # alias Alerts.Alert
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header><%= @title %></.header>
+
+      <.list>
+        <:item title="Short Header"><%= @alert.short_header %></:item>
+        <:item title="Header"><%= @alert.header %></:item>
+        <:item title="Description"><%= @alert.description %></:item>
+        <:item title="Banner"><%= @alert.banner %></:item>
+        <:item title="URL"><%= @alert.url %></:item>
+        <:item title="Effect"><%= humanized_atom(@alert.effect) %></:item>
+        <:item title="Service Effect"><%= @alert.service_effect %></:item>
+        <:item title="Cause"><%= humanized_atom(@alert.cause) %></:item>
+        <:item title="Lifecycle"><%= humanized_atom(@alert.lifecycle) %></:item>
+        <:item title="Timeframe"><%= @alert.timeframe %></:item>
+        <:item title="Severity"><%= @alert.severity %></:item>
+        <:item title="Active Period">
+          <.list_active_periods active_periods={@alert.active_period} />
+        </:item>
+        <:item title="informed_entity">
+          <div :for={informed_entity <- @alert.informed_entity}>
+            <%= inspect(informed_entity) %>
+          </div>
+        </:item>/
+        <:item title="Created At">
+          <.date_time date_time={@alert.created_at} /> (<%= @alert.created_at %>)
+        </:item>
+        <:item title="Updated At">
+          <.date_time date_time={@alert.updated_at} /> (<%= @alert.updated_at %>)
+        </:item>
+      </.list>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a list of alert active periods using human-friendly formatting.
+  """
+  attr :active_periods, :list, required: true
+
+  def list_active_periods(assigns) do
+    ~H"""
+    <ol>
+      <li :for={{starting_dt, endind_dt} <- @active_periods} class="whitespace-nowrap">
+        <.date_time date_time={starting_dt} /> – <.date_time date_time={endind_dt} />
+        (<%= starting_dt %> – <%= endind_dt %>)
+      </li>
+    </ol>
+    """
+  end
+end

--- a/lib/alerts_viewer_web/live/alerts_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_live.html.heex
@@ -29,7 +29,7 @@
   />
 </form>
 
-<.table id="alerts" rows={@alerts}>
+<.table id="alerts" rows={@alerts} row_click={&JS.patch(~p"/alerts/#{&1}")}>
   <:col :let={alert} label="ID">
     <%= alert.id %>
   </:col>
@@ -37,7 +37,10 @@
     <.informed_entity_icons entities={Alerts.Alert.entities_with_icons(alert)} />
   </:col>
   <:col :let={alert} label="Effect">
-    <%= humanized_effect_name(alert.effect) %>
+    <%= humanized_atom(alert.effect) %>
+  </:col>
+  <:col :let={alert} label="Lifecycle">
+    <%= humanized_atom(alert.lifecycle) %>
   </:col>
   <:col :let={alert} label="Message">
     <%= alert.short_header %>
@@ -55,3 +58,12 @@
     />
   </:col>
 </.table>
+
+<.modal :if={@live_action == :show} id="alert-modal" show on_cancel={JS.navigate(~p"/alerts")}>
+  <.live_component
+    module={AlertsViewerWeb.AlertComponent}
+    id={@alert.id}
+    title={@page_title}
+    alert={@alert}
+  />
+</.modal>

--- a/lib/alerts_viewer_web/live/alerts_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_live.html.heex
@@ -1,4 +1,6 @@
-<h1 class="pb-6">Alerts</h1>
+<.header class="pb-6">
+  Alerts
+</.header>
 
 <form phx-change="filter" class="flex gap-2">
   <.input
@@ -16,7 +18,6 @@
     ]}
     errors={[]}
   />
-
   <.input
     type="select"
     id="effect-filter"

--- a/lib/alerts_viewer_web/router.ex
+++ b/lib/alerts_viewer_web/router.ex
@@ -19,7 +19,8 @@ defmodule AlertsViewerWeb.Router do
 
     get "/", PageController, :home
 
-    live "/alerts", AlertsLive
+    live "/alerts", AlertsLive, :index
+    live "/alerts/:id", AlertsLive, :show
   end
 
   # Other scopes may use custom stacks.

--- a/lib/alerts_viewer_web/string_helpers.ex
+++ b/lib/alerts_viewer_web/string_helpers.ex
@@ -1,0 +1,21 @@
+defmodule AlertsViewerWeb.StringHelpers do
+  @moduledoc """
+  Utility functions for formatting strings and atoms.
+  """
+
+  @doc """
+  Return a human-friendly string for an atom.
+
+  iex> humanized_atom(:delay)
+  "Delay"
+  iex> humanized_atom(:service_change)
+  "Service Change"
+  """
+  @spec humanized_atom(atom) :: String.t()
+  def humanized_atom(effect_atom) do
+    effect_atom
+    |> Atom.to_string()
+    |> String.split("_")
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+end

--- a/test/alerts_test.exs
+++ b/test/alerts_test.exs
@@ -1,7 +1,9 @@
 defmodule AlertsTest do
   use ExUnit.Case, async: true
 
-  alias alias Alerts.AlertsPubSub
+  alias Alerts.{Alert, AlertsPubSub, Store}
+
+  @alert %Alert{id: "1", header: "Alert 1"}
 
   describe "subscribe/0" do
     setup do
@@ -25,11 +27,46 @@ defmodule AlertsTest do
       subscribe_fn = fn _, _ -> :ok end
       {:ok, pid} = AlertsPubSub.start_link(subscribe_fn: subscribe_fn)
 
+      :sys.replace_state(pid, fn state ->
+        store =
+          Store.init()
+          |> Store.add([@alert])
+
+        Map.put(state, :store, store)
+      end)
+
       {:ok, pid: pid}
     end
 
     test "returns a list of alerts" do
-      assert [] = Alerts.all()
+      assert Alerts.all() == [@alert]
+    end
+  end
+
+  describe "get/1" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :alerts_subscriptions_registry})
+
+      subscribe_fn = fn _, _ -> :ok end
+      {:ok, pid} = AlertsPubSub.start_link(subscribe_fn: subscribe_fn)
+
+      :sys.replace_state(pid, fn state ->
+        store =
+          Store.init()
+          |> Store.add([@alert])
+
+        Map.put(state, :store, store)
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "returns the requested alert" do
+      assert Alerts.get("1") == {:ok, @alert}
+    end
+
+    test "returns :not_found if the requested alert is not in the store" do
+      assert Alerts.get("missing") == :not_found
     end
   end
 end

--- a/test/alerts_viewer_web/live/alerts_live_test.exs
+++ b/test/alerts_viewer_web/live/alerts_live_test.exs
@@ -30,7 +30,7 @@ defmodule AlertsViewerWeb.AlertsLiveTest do
 
     test "connected mount", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/alerts")
-      assert html =~ ~r/<h1.*>Alerts<\/h1>/
+      assert html =~ ~r/Alerts/
     end
 
     test "handles alerts", %{conn: conn} do

--- a/test/alerts_viewer_web/string_helpers_test.exs
+++ b/test/alerts_viewer_web/string_helpers_test.exs
@@ -1,0 +1,7 @@
+defmodule AlertsViewerWeb.StringHelpersTest do
+  use ExUnit.Case, async: true
+
+  import AlertsViewerWeb.StringHelpers
+
+  doctest AlertsViewerWeb.StringHelpers
+end


### PR DESCRIPTION
Display raw informed entity data for now.

Also:

- feat: Get an alert
- style: Use the header component
- style: Remove padding on the select component
Options with long names were overlapping with the disclosure triangle.