### PR TITLE
docs: Link to the architecture doc from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ AlertsViewer is an internal project helping us with myriad alert-related needs. 
 - explore existing bus delay alerts
 - experiment with determining when alerts should be created
 
+
+## Architecture
+
+[AlertsViewer application architecture](ARCHITECTURE.md)
+
 ## Development
 
 To start your Phoenix server:


### PR DESCRIPTION
No ticket, I just noticed that this was missing while walking through the codebase.