### PR TITLE
Adds SIGNAL_ISSUE as cause in alerts parser

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -57,6 +57,7 @@ defmodule Alerts.Alert do
           | :police_activity
           | :power_problem
           | :severe_weather
+          | :signal_issue
           | :signal_problem
           | :slippery_rail
           | :snow

--- a/lib/alerts/parser.ex
+++ b/lib/alerts/parser.ex
@@ -87,6 +87,7 @@ defmodule Alerts.Parser do
   defp cause("POLICE_ACTIVITY"), do: :police_activity
   defp cause("POWER_PROBLEM"), do: :power_problem
   defp cause("SEVERE_WEATHER"), do: :severe_weather
+  defp cause("SIGNAL_ISSUE"), do: :signal_issue
   defp cause("SIGNAL_PROBLEM"), do: :signal_problem
   defp cause("SLIPPERY_RAIL"), do: :slippery_rail
   defp cause("SNOW"), do: :snow


### PR DESCRIPTION
It was missing, but now, it's here

🚦