### PR TITLE
Show alert severity and age

### DIFF
--- a/lib/alerts.ex
+++ b/lib/alerts.ex
@@ -49,7 +49,8 @@ defmodule Alerts do
           route_id => [
             %{
               severity: alert.severity,
-              created_at: alert.created_at
+              created_at: alert.created_at,
+              id: alert.id
             }
           ]
         })

--- a/lib/alerts_viewer_web/live/bus_live.ex
+++ b/lib/alerts_viewer_web/live/bus_live.ex
@@ -22,6 +22,8 @@ defmodule AlertsViewerWeb.BusLive do
 
     routes_with_current_alerts = Enum.filter(bus_routes, &delay_alert?(&1, bus_alerts))
 
+    alerts_by_route = Alerts.by_route(bus_alerts)
+
     socket =
       assign(socket,
         algorithm_options: algorithm_options,
@@ -29,6 +31,7 @@ defmodule AlertsViewerWeb.BusLive do
         filter_rows?: false,
         bus_routes: bus_routes,
         stats_by_route: stats_by_route,
+        alerts_by_route: alerts_by_route,
         routes_with_current_alerts: routes_with_current_alerts,
         routes_with_recommended_alerts: [],
         prediction_results: prediction_results(bus_routes, routes_with_current_alerts, [])
@@ -56,9 +59,12 @@ defmodule AlertsViewerWeb.BusLive do
     routes_with_current_alerts =
       Enum.filter(socket.assigns.bus_routes, &delay_alert?(&1, bus_alerts))
 
+    alerts_by_route = Alerts.by_route(bus_alerts)
+
     socket =
       assign(socket,
         routes_with_current_alerts: routes_with_current_alerts,
+        alerts_by_route: alerts_by_route,
         prediction_results:
           prediction_results(
             socket.assigns.bus_routes,
@@ -121,11 +127,30 @@ defmodule AlertsViewerWeb.BusLive do
     """
   end
 
+  def severity_to_minutes(severity) when severity < 3, do: "<10"
+  def severity_to_minutes(severity) when severity >= 9, do: "60+"
+
+  def severity_to_minutes(severity) do
+    %{
+      3 => "10",
+      4 => "15",
+      5 => "20",
+      6 => "25",
+      7 => "30",
+      8 => "30+"
+    }[severity]
+  end
+
   @spec seconds_to_minutes(nil | number) :: nil | float
   def seconds_to_minutes(nil), do: nil
 
   def seconds_to_minutes(seconds) do
     (seconds / 60) |> Float.round(1)
+  end
+
+  def alert_duration(alert) do
+    (DateTime.diff(DateTime.now!("America/New_York"), alert.created_at) / 3600)
+    |> Float.round(1)
   end
 
   @spec prediction_results([Route.t()], [Route.t()], [Route.t()]) :: PredictionResults.t()

--- a/lib/alerts_viewer_web/live/bus_live.ex
+++ b/lib/alerts_viewer_web/live/bus_live.ex
@@ -128,18 +128,13 @@ defmodule AlertsViewerWeb.BusLive do
   end
 
   def severity_to_minutes(severity) when severity < 3, do: "<10"
+  def severity_to_minutes(3), do: "10"
+  def severity_to_minutes(4), do: "15"
+  def severity_to_minutes(5), do: "20"
+  def severity_to_minutes(6), do: "25"
+  def severity_to_minutes(7), do: "30"
+  def severity_to_minutes(8), do: "30+"
   def severity_to_minutes(severity) when severity >= 9, do: "60+"
-
-  def severity_to_minutes(severity) do
-    %{
-      3 => "10",
-      4 => "15",
-      5 => "20",
-      6 => "25",
-      7 => "30",
-      8 => "30+"
-    }[severity]
-  end
 
   @spec seconds_to_minutes(nil | number) :: nil | float
   def seconds_to_minutes(nil), do: nil

--- a/lib/alerts_viewer_web/live/bus_live.html.heex
+++ b/lib/alerts_viewer_web/live/bus_live.html.heex
@@ -73,10 +73,22 @@
     |> seconds_to_minutes() %>
   </:col>
   <:col :let={route} label="Current Alert">
-    <div class="flex gap-1 items-end">
-      <.alert_icon :if={Enum.member?(@routes_with_current_alerts, route)} />
+    <div
+      :if={Enum.member?(@routes_with_current_alerts, route)}
+      class="flex flex-row gap-1 items-end"
+      data-bs-toggle="tooltip"
+      data-bs-placement="top"
+      title={"Open for #{alert_duration(hd(@alerts_by_route[route.id]))} hours "}
+    >
+      <div>
+        <.alert_icon />
+      </div>
+      <div>
+        <%= severity_to_minutes(hd(@alerts_by_route[route.id]).severity) %>
+      </div>
     </div>
   </:col>
+
   <:col :let={route} label="Recommending Alert">
     <span :if={Enum.member?(@routes_with_recommended_alerts, route)}>
       🤖

--- a/test/alerts_test.exs
+++ b/test/alerts_test.exs
@@ -193,16 +193,25 @@ defmodule AlertsTest do
         ]
       }
 
-      expected = %{
-        "28" => [%{severity: 3, created_at: now, id: alert1.id}],
-        "29" => [
-          %{severity: 4, created_at: now, id: alert2.id},
-          %{severity: 3, created_at: now, id: alert1.id}
-        ],
-        "30" => [%{severity: 5, created_at: now, id: alert3.id}]
+      secret_evil_alert = %Alert{
+        id: 3,
+        severity: nil,
+        created_at: nil,
+        informed_entity: [
+          %{route: nil, route_type: nil}
+        ]
       }
 
-      actual = Alerts.by_route([alert1, alert2, alert3])
+      expected = %{
+        "28" => [alert1],
+        "29" => [
+          alert2,
+          alert1
+        ],
+        "30" => [alert3]
+      }
+
+      actual = Alerts.by_route([alert1, alert2, alert3, secret_evil_alert])
 
       assert expected == actual
     end

--- a/test/alerts_test.exs
+++ b/test/alerts_test.exs
@@ -160,4 +160,51 @@ defmodule AlertsTest do
       assert Alerts.search([foo_alert, bar_alert], "foo") == [foo_alert]
     end
   end
+
+  describe "by_route/1" do
+    test "returns map of alerts keyed on route id" do
+      now = DateTime.now!("America/New_York")
+
+      alert1 = %Alert{
+        id: 1,
+        severity: 3,
+        created_at: now,
+        informed_entity: [
+          %{route: "28", route_type: 3},
+          %{route: "29", route_type: 3}
+        ]
+      }
+
+      alert2 = %Alert{
+        id: 2,
+        severity: 4,
+        created_at: now,
+        informed_entity: [
+          %{route: "29", route_type: 3}
+        ]
+      }
+
+      alert3 = %Alert{
+        id: 3,
+        severity: 5,
+        created_at: now,
+        informed_entity: [
+          %{route: "30", route_type: 3}
+        ]
+      }
+
+      expected = %{
+        "28" => [%{severity: 3, created_at: now, id: alert1.id}],
+        "29" => [
+          %{severity: 4, created_at: now, id: alert2.id},
+          %{severity: 3, created_at: now, id: alert1.id}
+        ],
+        "30" => [%{severity: 5, created_at: now, id: alert3.id}]
+      }
+
+      actual = Alerts.by_route([alert1, alert2, alert3])
+
+      assert expected == actual
+    end
+  end
 end


### PR DESCRIPTION
Displays actual alerts' severity and age. Adds a function to Alerts to arrange alerts data to make it easier to parse.

![Screenshot 2023-05-26 at 2 56 17 PM](https://github.com/mbta/alerts_viewer/assets/17047573/a52341b4-8d86-4145-993a-ebe9d49f4730)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204597186510077