### PR TITLE
Block Waivers from Trip Updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,3 +15,7 @@ The [MBTA API](https://www.mbta.com/developers/v3-api) provides information abou
 ### Swiftly
 
 Swiftly is a company we use to provide predictions for our bus arrivals. As a part of this, they provide a real-time bus vehicle data feed. This largely overlaps with the Vehicle Positions data we generate as part of our [GTFS-rt feed](https://www.mbta.com/developers/gtfs-realtime), but they include some extra data. In particul far this application, they include a measurement of the bus's current "schedule adherence", which is how late or early they are from where they should be right now based on the schedule.
+
+### GTFS-realtime Trip Updates
+
+We use the [GTFS-realtime Trip Updates feed](https://s3.amazonaws.com/mbta-busloc-s3/staging/TripUpdates_enhanced.json) to get information about trip updates and stop updates.

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,8 @@ config :alerts_viewer,
   ],
   swiftly_authorization_key: {:system, "SWIFTLY_AUTHORIZATION_KEY"},
   swiftly_realtime_vehicles_url: {:system, "SWIFTLY_REALTIME_VEHICLES_URL"},
-  start_data_processes: true
+  start_data_processes: true,
+  trip_updates_url: {:system, "TRIP_UPDATES_URL"}
 
 # Configures the endpoint
 config :alerts_viewer, AlertsViewerWeb.Endpoint,

--- a/env.example
+++ b/env.example
@@ -2,3 +2,4 @@ API_KEY=
 API_URL=https://api-dev.mbtace.com/
 SWIFTLY_AUTHORIZATION_KEY=
 SWIFTLY_REALTIME_VEHICLES_URL=https://api.goswift.ly/real-time/mbta-bus/vehicles?verbose=true
+export TRIP_UPDATES_URL=https://s3.amazonaws.com/mbta-busloc-s3/staging/TripUpdates_enhanced.json

--- a/lib/alerts_viewer/application.ex
+++ b/lib/alerts_viewer/application.ex
@@ -15,8 +15,8 @@ defmodule AlertsViewer.Application do
           Alerts.Supervisor,
           Routes.Supervisor,
           Vehicles.Supervisor,
-          TripUpdates.GTFSSupervisor,
-          TripUpdates.Supervisor
+          TripUpdates.Supervisor,
+          TripUpdates.GTFSSupervisor
         ]
       else
         []

--- a/lib/alerts_viewer/application.ex
+++ b/lib/alerts_viewer/application.ex
@@ -14,7 +14,9 @@ defmodule AlertsViewer.Application do
         [
           Alerts.Supervisor,
           Routes.Supervisor,
-          Vehicles.Supervisor
+          Vehicles.Supervisor,
+          TripUpdates.GTFSSupervisor,
+          TripUpdates.Supervisor
         ]
       else
         []
@@ -60,7 +62,8 @@ defmodule AlertsViewer.Application do
       :api_url,
       :api_key,
       :swiftly_authorization_key,
-      :swiftly_realtime_vehicles_url
+      :swiftly_realtime_vehicles_url,
+      :trip_updates_url
     ]
 
     for application_key <- application_keys do

--- a/lib/alerts_viewer_web/live/bus_live.html.heex
+++ b/lib/alerts_viewer_web/live/bus_live.html.heex
@@ -44,7 +44,6 @@
     />
   </.controls_form>
 </div>
-
 <.table
   id="bus-routes"
   rows={
@@ -118,7 +117,11 @@
       </div>
     </div>
   </:col>
-
+  <:col :let={route} label="Route has Cancelled Trip">
+    <span :if={Enum.member?(@block_waivered_routes, Route.name(route))}>
+      🚧
+    </span>
+  </:col>
   <:col :let={route} label="Recommending Alert">
     <span :if={Enum.member?(@routes_with_recommended_alerts, route)}>
       🤖

--- a/lib/trip_updates/gtfs_supervisor.ex
+++ b/lib/trip_updates/gtfs_supervisor.ex
@@ -1,0 +1,48 @@
+defmodule TripUpdates.GTFSSupervisor do
+  @moduledoc """
+  Supervisor for realtime tripupdate information from realtime GTFS.
+  """
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    trip_updates_url =
+      Keyword.get(
+        opts,
+        :trip_updates_url,
+        Application.get_env(:alerts_viewer, :trip_updates_url)
+      )
+
+    source =
+      http_source(
+        :trip_updates,
+        trip_updates_url,
+        TripUpdates.Parser.GTFSRealtimeEnhanced,
+        headers: %{},
+        params: %{}
+      )
+
+    consumer =
+      Supervisor.child_spec(
+        {TripUpdates.TripUpdates, subscribe_to: [{:trip_updates, [max_demand: 1]}]},
+        []
+      )
+
+    Supervisor.init([source, consumer], strategy: :one_for_one)
+  end
+
+  @spec http_source(term(), String.t(), module(), keyword()) :: Supervisor.child_spec()
+  defp http_source(source, url, parser, opts) do
+    Supervisor.child_spec(
+      {
+        HttpProducer,
+        {url, [name: source, parser: parser] ++ opts}
+      },
+      id: source
+    )
+  end
+end

--- a/lib/trip_updates/parser/gtfs_realtime_enhanced.ex
+++ b/lib/trip_updates/parser/gtfs_realtime_enhanced.ex
@@ -21,7 +21,7 @@ defmodule TripUpdates.Parser.GTFSRealtimeEnhanced do
 
   defp decode_feed_entity(_), do: []
 
-  @spec decode_trip_update(map) :: [struct, ...]
+  @spec decode_trip_update(map) :: [TripUpdate.t()]
   def decode_trip_update(trip_update) do
     trip = decode_trip(Map.get(trip_update, "trip"))
 
@@ -55,7 +55,7 @@ defmodule TripUpdates.Parser.GTFSRealtimeEnhanced do
     )
   end
 
-  @spec decode_trip(nil | map) :: nil | struct
+  @spec decode_trip(nil | map) :: nil | Trip.t()
   defp decode_trip(nil), do: nil
 
   defp decode_trip(trip) do

--- a/lib/trip_updates/parser/gtfs_realtime_enhanced.ex
+++ b/lib/trip_updates/parser/gtfs_realtime_enhanced.ex
@@ -1,0 +1,107 @@
+defmodule TripUpdates.Parser.GTFSRealtimeEnhanced do
+  @moduledoc """
+  Parser for GTFS-RT enhanced JSON files.
+  """
+
+  require Logger
+  alias TripUpdates.{StopTimeUpdate, Trip, TripUpdate}
+
+  def parse(binary) when is_binary(binary) do
+    binary
+    |> Jason.decode!(strings: :copy)
+    |> decode_entities()
+  end
+
+  @spec decode_entities(map()) :: [TripUpdate.t() | StopTimeUpdate.t()]
+  defp decode_entities(%{"entity" => entities}),
+    do: Enum.flat_map(entities, &decode_feed_entity(&1))
+
+  defp decode_feed_entity(%{"trip_update" => %{} = trip_update}),
+    do: decode_trip_update(trip_update)
+
+  defp decode_feed_entity(_), do: []
+
+  @spec decode_trip_update(map) :: [struct, ...]
+  def decode_trip_update(trip_update) do
+    trip = decode_trip(Map.get(trip_update, "trip"))
+
+    stop_time_updates =
+      Map.get(trip_update, "stop_time_update") |> Enum.map(&decode_stop_update(&1))
+
+    [
+      TripUpdate.new(
+        stop_time_update: stop_time_updates,
+        timestamp: Map.get(trip_update, "timestamp"),
+        trip: trip
+      )
+    ]
+  end
+
+  defp decode_stop_update(stu) do
+    {arrival_time, arrival_uncertainty} = time_from_event(Map.get(stu, "arrival"))
+    {departure_time, departure_uncertainty} = time_from_event(Map.get(stu, "departure"))
+
+    StopTimeUpdate.new(
+      stop_id: Map.get(stu, "stop_id"),
+      stop_sequence: Map.get(stu, "stop_sequence"),
+      schedule_relationship: schedule_relationship(Map.get(stu, "schedule_relationship")),
+      arrival_time: arrival_time,
+      departure_time: departure_time,
+      uncertainty: arrival_uncertainty || departure_uncertainty,
+      status: Map.get(stu, "boarding_status"),
+      cause_id: Map.get(stu, "cause_id"),
+      cause_description: Map.get(stu, "cause_description"),
+      remark: Map.get(stu, "remark")
+    )
+  end
+
+  @spec decode_trip(nil | map) :: nil | struct
+  defp decode_trip(nil), do: nil
+
+  defp decode_trip(trip) do
+    Trip.new(
+      trip_id: Map.get(trip, "trip_id"),
+      route_id: Map.get(trip, "route_id"),
+      direction_id: Map.get(trip, "direction_id"),
+      start_date: date(Map.get(trip, "start_date")),
+      start_time: Map.get(trip, "start_time"),
+      schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship"))
+    )
+  end
+
+  @spec date(String.t() | nil) :: :calendar.date() | nil
+  def date(nil) do
+    nil
+  end
+
+  def date(<<year_str::binary-4, month_str::binary-2, day_str::binary-2>>) do
+    {
+      String.to_integer(year_str),
+      String.to_integer(month_str),
+      String.to_integer(day_str)
+    }
+  end
+
+  def date(date) when is_binary(date) do
+    {:ok, date} = Date.from_iso8601(date)
+    Date.to_erl(date)
+  end
+
+  defp time_from_event(nil), do: {nil, nil}
+  defp time_from_event(%{"time" => time} = map), do: {time, Map.get(map, "uncertainty", nil)}
+
+  @spec schedule_relationship(String.t() | nil) :: atom()
+  defp schedule_relationship(nil), do: :SCHEDULED
+
+  for relationship <- ~w(SCHEDULED ADDED UNSCHEDULED CANCELED SKIPPED NO_DATA)a do
+    defp schedule_relationship(unquote(Atom.to_string(relationship))), do: unquote(relationship)
+  end
+
+  @spec current_status(String.t() | nil) :: atom()
+  # default
+  defp current_status(nil), do: :IN_TRANSIT_TO
+
+  for status <- ~w(INCOMING_AT STOPPED_AT IN_TRANSIT_TO)a do
+    defp current_status(unquote(Atom.to_string(status))), do: unquote(status)
+  end
+end

--- a/lib/trip_updates/stop_time_update.ex
+++ b/lib/trip_updates/stop_time_update.ex
@@ -1,0 +1,58 @@
+defmodule TripUpdates.StopTimeUpdate do
+  @moduledoc """
+  Structure for representing an update to a StopTime (e.g. a predicted arrival or departure)
+  """
+
+  # The full mapping between "cause_description" and "cause_id":
+  # B - Manpower	      23
+  # C - No Equipment	  24
+  # D - Disabled Bus	  25
+  # E - Diverted	      26
+  # F - Traffic	        27
+  # G - Accident	      28
+  # H - Weather	        29
+  # I - Operator Error	30
+  # J - Other	          1
+  # K - Adjusted	      31
+  # L - Shuttle	        32
+  # T - Inactive TM	    33
+
+  defstruct [
+    :arrival_time,
+    :departure_time,
+    :uncertainty,
+    :stop_id,
+    :stop_sequence,
+    :cause_description,
+    :cause_id,
+    :remark,
+    :schedule_relationship,
+    :status
+  ]
+
+  @type t :: %__MODULE__{
+          arrival_time: integer() | nil,
+          departure_time: integer() | nil,
+          uncertainty: integer() | nil,
+          stop_id: integer() | nil,
+          stop_sequence: integer() | nil,
+          cause_description: String.t() | nil,
+          cause_id: String.t() | nil,
+          remark: String.t() | nil,
+          schedule_relationship: String.t() | nil,
+          status: String.t() | nil
+        }
+
+  def new(fields) do
+    struct!(__MODULE__, fields)
+  end
+
+  @spec is_block_waiver?(__MODULE__.t()) :: boolean()
+  def is_block_waiver?(stop_time_update) do
+    # cause_id 33 is bad TransitMaster units.
+    # Since we can fall back to swiftly data,
+    # these block waivers don't matter to people using skate.
+    stop_time_update.cause_id != nil and
+      stop_time_update.cause_id != 33
+  end
+end

--- a/lib/trip_updates/supervisor.ex
+++ b/lib/trip_updates/supervisor.ex
@@ -1,0 +1,20 @@
+defmodule TripUpdates.Supervisor do
+  @moduledoc """
+  Supervisor for Trip Updates application. Supports subscribing to blocked routes.
+  """
+
+  use Supervisor
+
+  def start_link(_opts) do
+    Supervisor.start_link(__MODULE__, :ok)
+  end
+
+  def init(:ok) do
+    children = [
+      {Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry},
+      TripUpdates.TripUpdatesPubSub
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/trip_updates/trip.ex
+++ b/lib/trip_updates/trip.ex
@@ -1,0 +1,29 @@
+defmodule TripUpdates.Trip do
+  @moduledoc """
+  Structure for representing a trip
+  """
+
+  defstruct [
+    :direction_id,
+    :route_id,
+    :start_date,
+    :start_time,
+    :trip_id,
+    :route_pattern_id,
+    :schedule_relationship
+  ]
+
+  @type t :: %__MODULE__{
+          direction_id: String.t() | nil,
+          route_id: String.t() | nil,
+          start_date: integer() | nil,
+          start_time: integer() | nil,
+          trip_id: String.t(),
+          route_pattern_id: String.t() | nil,
+          schedule_relationship: String.t() | nil
+        }
+
+  def new(fields) do
+    struct!(__MODULE__, fields)
+  end
+end

--- a/lib/trip_updates/trip_update.ex
+++ b/lib/trip_updates/trip_update.ex
@@ -1,0 +1,28 @@
+defmodule TripUpdates.TripUpdate do
+  @moduledoc """
+  TripUpdate represents a (potential) change to a GTFS trip.
+  """
+
+  alias TripUpdates.{StopTimeUpdate, Trip}
+
+  defstruct [
+    :overload_offset,
+    :start_date,
+    :start_time,
+    :trip,
+    :stop_time_update,
+    :timestamp
+  ]
+
+  @type t :: %__MODULE__{
+          start_date: integer() | nil,
+          start_time: integer() | nil,
+          trip: Trip,
+          stop_time_update: [StopTimeUpdate],
+          timestamp: integer() | nil
+        }
+
+  def new(fields) do
+    struct!(__MODULE__, fields)
+  end
+end

--- a/lib/trip_updates/trip_update.ex
+++ b/lib/trip_updates/trip_update.ex
@@ -17,8 +17,8 @@ defmodule TripUpdates.TripUpdate do
   @type t :: %__MODULE__{
           start_date: integer() | nil,
           start_time: integer() | nil,
-          trip: Trip,
-          stop_time_update: [StopTimeUpdate],
+          trip: Trip.t(),
+          stop_time_update: [StopTimeUpdate.t()],
           timestamp: integer() | nil
         }
 

--- a/lib/trip_updates/trip_updates.ex
+++ b/lib/trip_updates/trip_updates.ex
@@ -24,7 +24,8 @@ defmodule TripUpdates.TripUpdates do
 
   @impl GenStage
   def handle_events(events, _from, state) do
-    List.last(events)
+    events
+    |> List.last()
     |> TripUpdatesPubSub.update_block_waivered_routes()
 
     {:noreply, [], state}

--- a/lib/trip_updates/trip_updates.ex
+++ b/lib/trip_updates/trip_updates.ex
@@ -1,0 +1,32 @@
+defmodule TripUpdates.TripUpdates do
+  @moduledoc """
+  Consumes output from the Trip Updates GTFS feed and reports them to the realtime server.
+  """
+  use GenStage
+
+  alias TripUpdates.{StopTimeUpdate, TripUpdatesPubSub}
+  @type t :: %{String.t() => [StopTimeUpdate.t()]}
+
+  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts)
+  end
+
+  @impl GenStage
+  def init(opts) do
+    {:consumer, :the_state_does_not_matter, opts}
+  end
+
+  # If we get a reply after we've already timed out, ignore it
+  @impl GenStage
+  def handle_info({reference, _}, state) when is_reference(reference),
+    do: {:noreply, [], state}
+
+  @impl GenStage
+  def handle_events(events, _from, state) do
+    List.last(events)
+    |> TripUpdatesPubSub.update_block_waivered_routes()
+
+    {:noreply, [], state}
+  end
+end

--- a/lib/trip_updates/trip_updates_pub_sub.ex
+++ b/lib/trip_updates/trip_updates_pub_sub.ex
@@ -7,6 +7,10 @@ defmodule TripUpdates.TripUpdatesPubSub do
 
   defstruct block_waivered_routes: []
 
+  @type t :: %__MODULE__{
+          block_waivered_routes: [String.t()]
+        }
+
   # Client
 
   @spec start_link() :: GenServer.on_start()
@@ -21,7 +25,7 @@ defmodule TripUpdates.TripUpdatesPubSub do
     )
   end
 
-  @spec subscribe(atom | pid | {atom, any} | {:via, atom, any}) :: any
+  @spec subscribe(atom | pid | {atom, any} | {:via, atom, any}) :: __MODULE__.t()
   def subscribe(server \\ __MODULE__) do
     {registry_key, block_waivered_routes} = GenServer.call(server, :subscribe)
     Registry.register(:trip_updates_subscriptions_registry, registry_key, :value_does_not_matter)

--- a/lib/trip_updates/trip_updates_pub_sub.ex
+++ b/lib/trip_updates/trip_updates_pub_sub.ex
@@ -1,0 +1,102 @@
+defmodule TripUpdates.TripUpdatesPubSub do
+  @moduledoc """
+  Publish a list of blocked routes to subscribers.
+  """
+  use GenServer
+  alias TripUpdates.{StopTimeUpdate, TripUpdates}
+
+  defstruct block_waivered_routes: []
+
+  # Client
+
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @spec subscribe(atom | pid | {atom, any} | {:via, atom, any}) :: any
+  def subscribe(server \\ __MODULE__) do
+    {registry_key, block_waivered_routes} = GenServer.call(server, :subscribe)
+    Registry.register(:trip_updates_subscriptions_registry, registry_key, :value_does_not_matter)
+    block_waivered_routes
+  end
+
+  def all(server \\ __MODULE__), do: GenServer.call(server, :all)
+
+  @spec update_block_waivered_routes(
+          [TripUpdates.t()],
+          atom | pid | {atom, any} | {:via, atom, any}
+        ) :: :ok
+  def update_block_waivered_routes(trip_updates, server \\ __MODULE__) do
+    # puts into state a list of routes which have gotten a trip update
+    # where all the stop updates have a cancellation reason
+    block_waivered_routes =
+      trip_updates
+      |> Enum.filter(&are_all_cancelled?(&1))
+      |> Enum.group_by(& &1.trip.route_id)
+      |> Map.keys()
+
+    GenServer.cast(server, {:update_block_waivered_routes, block_waivered_routes})
+  end
+
+  # Server
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, %__MODULE__{}}
+  end
+
+  @impl GenServer
+  def handle_call(
+        :subscribe,
+        _from,
+        %__MODULE__{block_waivered_routes: block_waivered_routes} = state
+      ) do
+    registry_key = self()
+    {:reply, {registry_key, block_waivered_routes}, state}
+  end
+
+  @impl GenServer
+  def handle_call(:all, _from, %__MODULE__{block_waivered_routes: block_waivered_routes} = state) do
+    {:reply, block_waivered_routes, state}
+  end
+
+  @impl GenServer
+  def handle_cast(
+        {:update_block_waivered_routes, block_waivered_routes},
+        %__MODULE__{} = state
+      ) do
+    new_state = %__MODULE__{
+      state
+      | block_waivered_routes: block_waivered_routes
+    }
+
+    :ok = broadcast(new_state)
+
+    {:noreply, new_state}
+  end
+
+  defp broadcast(%__MODULE__{block_waivered_routes: block_waivered_routes}) do
+    registry_key = self()
+
+    Registry.dispatch(:trip_updates_subscriptions_registry, registry_key, fn entries ->
+      Enum.each(entries, &send_data(&1, block_waivered_routes))
+    end)
+  end
+
+  defp send_data({pid, _}, block_waivered_routes),
+    do: send(pid, {:block_waivered_routes, block_waivered_routes})
+
+  defp are_all_cancelled?(trip_update) do
+    Enum.all?(trip_update.stop_time_update, fn update ->
+      StopTimeUpdate.is_block_waiver?(update)
+    end)
+  end
+end

--- a/test/alerts_viewer_web/live/bus_live_test.exs
+++ b/test/alerts_viewer_web/live/bus_live_test.exs
@@ -8,6 +8,7 @@ defmodule AlertsViewerWeb.BusLiveTest do
   alias Alerts.AlertsPubSub
   alias Plug.Conn
   alias Routes.RouteStatsPubSub
+  alias TripUpdates.TripUpdatesPubSub
 
   describe "bus live page" do
     setup do
@@ -16,6 +17,8 @@ defmodule AlertsViewerWeb.BusLiveTest do
       {:ok, _pid} = AlertsPubSub.start_link(subscribe_fn: subscribe_fn)
       start_supervised({Registry, keys: :duplicate, name: :route_stats_subscriptions_registry})
       {:ok, _pid} = RouteStatsPubSub.start_link()
+      start_supervised({Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry})
+      {:ok, _pid} = TripUpdatesPubSub.start_link()
 
       bypass = Bypass.open()
       reassign_env(:alerts_viewer, :api_url, "http://localhost:#{bypass.port}")

--- a/test/support/fixtures/trip_updates_enhanced.json
+++ b/test/support/fixtures/trip_updates_enhanced.json
@@ -1,0 +1,3015 @@
+{
+    "entity": [
+        {
+            "alert": null,
+            "id": "C01-32:1:44170988:1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "1",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "108",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "106",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "58",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "99",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "188",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "95",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "6",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "88",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10003",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "93",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "109",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "107",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "97",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "102",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "57",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "87",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "104",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "91",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10590",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "89",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170988"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "C01-32:1:44170989:1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "1",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10003",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "6",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "99",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "108",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "87",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "57",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "102",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "104",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10590",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "91",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "88",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "188",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "89",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "93",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "97",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "95",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "58",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "107",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "106",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "109",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170989"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "C01-32:1:44170990:58",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "58",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "89",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "106",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "95",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "108",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "1",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "97",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "109",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "6",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10590",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "188",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "93",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "87",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "102",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "104",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "107",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "91",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10003",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "99",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "57",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "88",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170990"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "C01-32:1:44170997:82",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "82",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "856",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "72",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "73",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "66",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "59",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "69",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "79",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "80",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "854",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10100",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "84",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "68",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "71",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "77",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "75",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "187",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "63",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "62",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "67",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "83",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170997"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "C01-32:1:44170998:63",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "63",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "71",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "69",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "66",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "854",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10100",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "80",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "84",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "83",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "187",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "68",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "79",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "72",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "62",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "856",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "67",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "73",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "59",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "82",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "75",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "77",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170998"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "C01-32:1:44170999:59",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "59",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "82",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "63",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "72",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "110",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10100",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "77",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "68",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "69",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "79",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "187",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "73",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "71",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "67",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "80",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "854",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "10101",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "856",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "83",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "75",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "62",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "84",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "T - Inactive TM",
+                        "cause_id": 33,
+                        "departure": null,
+                        "remark": "T - Inactive TM:",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "66",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44170999"
+                },
+                "vehicle": {
+                    "id": "y1729",
+                    "label": "1729",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "S741-68:SL1:44169401:74613",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74613",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74612",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12006",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12005",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17091",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74624",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74611",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "SL1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44169401"
+                },
+                "vehicle": {
+                    "id": "y1130",
+                    "label": "1130",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "S741-68:SL1:44169406:12008",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12008",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17094",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "27092",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17093",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74615",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74616",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17095",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12007",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17096",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "17091",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74614",
+                        "stop_sequence": null
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": "D - Disabled Bus",
+                        "cause_id": 25,
+                        "departure": null,
+                        "remark": "D - Disabled Bus: D",
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "74617",
+                        "stop_sequence": null
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": null,
+                    "route_id": "SL1",
+                    "route_pattern_id": null,
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": null,
+                    "start_time": null,
+                    "trip_id": "44169406"
+                },
+                "vehicle": {
+                    "id": "y1130",
+                    "label": "1130",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44171643-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589819760,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "63",
+                        "stop_sequence": 24
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589820060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "64",
+                        "stop_sequence": 25
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 1,
+                    "route_id": "1",
+                    "route_pattern_id": "1-_-1",
+                    "schedule_relationship": "SCHEDULED",
+                    "start_date": "20200518",
+                    "start_time": "12:00:00",
+                    "trip_id": "44171643-OL1"
+                },
+                "vehicle": {
+                    "id": "y1730",
+                    "label": "1730",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44609578-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914080,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2829",
+                        "stop_sequence": 25
+                    },
+                    {
+                        "arrival": {
+                            "delay": 0,
+                            "time": 1589914140,
+                            "uncertainty": 0
+                        },
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": null,
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "8310",
+                        "stop_sequence": 26
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 1,
+                    "route_id": "111",
+                    "route_pattern_id": "111-5-1",
+                    "schedule_relationship": "ADDED",
+                    "start_date": "20200519",
+                    "start_time": "14:21:00",
+                    "trip_id": "44609578-OL1"
+                },
+                "vehicle": {
+                    "id": "y2012",
+                    "label": "2012",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44609337-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914500,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "8310",
+                        "stop_sequence": 1
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914620,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2832",
+                        "stop_sequence": 2
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914740,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12004",
+                        "stop_sequence": 3
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914920,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "12002",
+                        "stop_sequence": 4
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915040,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5611",
+                        "stop_sequence": 5
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915100,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5612",
+                        "stop_sequence": 6
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915160,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5613",
+                        "stop_sequence": 7
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915220,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5614",
+                        "stop_sequence": 8
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915280,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5615",
+                        "stop_sequence": 9
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915340,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "56170",
+                        "stop_sequence": 10
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915400,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5618",
+                        "stop_sequence": 11
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915460,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5619",
+                        "stop_sequence": 12
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915520,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5620",
+                        "stop_sequence": 13
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915580,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5621",
+                        "stop_sequence": 14
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915640,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5623",
+                        "stop_sequence": 15
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915640,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5624",
+                        "stop_sequence": 16
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915700,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5625",
+                        "stop_sequence": 17
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915760,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5626",
+                        "stop_sequence": 18
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915760,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5627",
+                        "stop_sequence": 19
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915820,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5628",
+                        "stop_sequence": 20
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915820,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5629",
+                        "stop_sequence": 21
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915880,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5630",
+                        "stop_sequence": 22
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915880,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5631",
+                        "stop_sequence": 23
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915940,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5632",
+                        "stop_sequence": 24
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589915940,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5633",
+                        "stop_sequence": 25
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589916060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5636",
+                        "stop_sequence": 26
+                    },
+                    {
+                        "arrival": {
+                            "delay": 0,
+                            "time": 1589916060,
+                            "uncertainty": 0
+                        },
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": null,
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5547",
+                        "stop_sequence": 27
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 0,
+                    "route_id": "111",
+                    "route_pattern_id": "111-5-0",
+                    "schedule_relationship": "ADDED",
+                    "start_date": "20200519",
+                    "start_time": "14:55:00",
+                    "trip_id": "44609337-OL1"
+                },
+                "vehicle": {
+                    "id": "y2012",
+                    "label": "2012",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44609996-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589913803,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5467",
+                        "stop_sequence": 31
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589913810,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5468",
+                        "stop_sequence": 32
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589913930,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5469",
+                        "stop_sequence": 33
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589914050,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5472",
+                        "stop_sequence": 34
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 0,
+                    "route_id": "106",
+                    "route_pattern_id": "106-_-0",
+                    "schedule_relationship": "ADDED",
+                    "start_date": "20200519",
+                    "start_time": "14:03:00",
+                    "trip_id": "44609996-OL1"
+                },
+                "vehicle": {
+                    "id": "y2036",
+                    "label": "2036",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44607586-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "14150",
+                        "stop_sequence": 1
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2606",
+                        "stop_sequence": 2
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2605",
+                        "stop_sequence": 3
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2607",
+                        "stop_sequence": 4
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2659",
+                        "stop_sequence": 5
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2660",
+                        "stop_sequence": 6
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2661",
+                        "stop_sequence": 7
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2662",
+                        "stop_sequence": 8
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895060,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2664",
+                        "stop_sequence": 9
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895105,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2665",
+                        "stop_sequence": 10
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895165,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2666",
+                        "stop_sequence": 11
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895165,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2667",
+                        "stop_sequence": 12
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895225,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2668",
+                        "stop_sequence": 13
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895285,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2669",
+                        "stop_sequence": 14
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895285,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2670",
+                        "stop_sequence": 15
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895345,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2671",
+                        "stop_sequence": 16
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895405,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2672",
+                        "stop_sequence": 17
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895465,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2673",
+                        "stop_sequence": 18
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895525,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2628",
+                        "stop_sequence": 19
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895585,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "5104",
+                        "stop_sequence": 20
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895645,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2630",
+                        "stop_sequence": 21
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895645,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2631",
+                        "stop_sequence": 22
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895645,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2632",
+                        "stop_sequence": 23
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895705,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2634",
+                        "stop_sequence": 24
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895765,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2635",
+                        "stop_sequence": 25
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895765,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2715",
+                        "stop_sequence": 26
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589895825,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2636",
+                        "stop_sequence": 27
+                    },
+                    {
+                        "arrival": {
+                            "delay": 0,
+                            "time": 1589895885,
+                            "uncertainty": 0
+                        },
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": null,
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "2637",
+                        "stop_sequence": 28
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 0,
+                    "route_id": "88",
+                    "route_pattern_id": "88-_-0",
+                    "schedule_relationship": "ADDED",
+                    "start_date": "20200519",
+                    "start_time": "09:10:00",
+                    "trip_id": "44607586-OL1"
+                },
+                "vehicle": {
+                    "id": "y1421",
+                    "label": "1421",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        },
+        {
+            "alert": null,
+            "id": "44166496-OL1",
+            "is_deleted": null,
+            "trip_update": {
+                "cause_description": null,
+                "cause_id": null,
+                "delay": null,
+                "remark": null,
+                "stop_time_update": [
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589912567,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "4563",
+                        "stop_sequence": 70
+                    },
+                    {
+                        "arrival": null,
+                        "cause_description": null,
+                        "cause_id": null,
+                        "departure": {
+                            "delay": 0,
+                            "time": 1589913420,
+                            "uncertainty": 0
+                        },
+                        "remark": null,
+                        "schedule_relationship": "SCHEDULED",
+                        "stop_id": "37150",
+                        "stop_sequence": 71
+                    }
+                ],
+                "timestamp": null,
+                "trip": {
+                    "direction_id": 0,
+                    "route_id": "455",
+                    "route_pattern_id": "455-7-0",
+                    "schedule_relationship": "ADDED",
+                    "start_date": "20200519",
+                    "start_time": "13:36:00",
+                    "trip_id": "44166496-OL1"
+                },
+                "vehicle": {
+                    "id": "y0860",
+                    "label": "0860",
+                    "license_plate": null
+                }
+            },
+            "vehicle": null
+        }
+    ],
+    "header": {
+        "gtfs_realtime_version": "2.0",
+        "incrementality": "FULL_DATASET",
+        "timestamp": 1589913930
+    }
+}

--- a/test/trip_updates/gtfs_supervisor_test.exs
+++ b/test/trip_updates/gtfs_supervisor_test.exs
@@ -1,0 +1,23 @@
+defmodule TripUpdates.GTFSSupervisorTest do
+  use ExUnit.Case, async: true
+
+  alias TripUpdates.GTFSSupervisor
+
+  @opts [
+    trip_updates_url: "http://example.com/realtime_trip_updates.json"
+  ]
+
+  describe "start_link/1" do
+    test "can start the application" do
+      assert {:ok, _pid} = GTFSSupervisor.start_link(@opts)
+    end
+  end
+
+  describe "init/1" do
+    test "sets up the data source and consumer" do
+      assert {:ok, {_sup_flags, children}} = GTFSSupervisor.init(@opts)
+
+      assert length(children) == 2
+    end
+  end
+end

--- a/test/trip_updates/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/trip_updates/parser/gtfs_realtime_enhanced_test.exs
@@ -1,0 +1,41 @@
+defmodule TripUpdates.Parser.GTFSRealtimeEnhancedTest do
+  use ExUnit.Case, async: true
+
+  import Test.Support.Helpers
+
+  alias TripUpdates.Parser.GTFSRealtimeEnhanced
+  alias TripUpdates.{StopTimeUpdate, TripUpdate}
+
+  describe "parse/1" do
+    test "parsing an enhanced TripUpdates JSON file returns TripUpdate and StopTimeUpdate structs" do
+      binary = File.read!(fixture_path("trip_updates_enhanced.json"))
+      parsed = GTFSRealtimeEnhanced.parse(binary)
+      assert is_list(parsed)
+      assert Enum.all?(parsed, &(&1.__struct__ in [TripUpdate]))
+    end
+
+    test "parsing a TripUpdates file preserves the remark field on StopTimeUpdate structs" do
+      binary = File.read!(fixture_path("trip_updates_enhanced.json"))
+
+      stop_time_updates = hd(GTFSRealtimeEnhanced.parse(binary)).stop_time_update
+
+      assert length(stop_time_updates) > 0
+      assert Enum.all?(stop_time_updates, &(&1.__struct__ in [StopTimeUpdate]))
+      assert Enum.all?(stop_time_updates, &match?(%{remark: _remark}, &1))
+    end
+  end
+
+  describe "date/1" do
+    test "parses an epoch string" do
+      assert GTFSRealtimeEnhanced.date("20190517") == {2019, 5, 17}
+    end
+
+    test "parses an ISO 8601:2004 string" do
+      assert GTFSRealtimeEnhanced.date("2015-01-23") == {2015, 1, 23}
+    end
+
+    test "returns nil when passed nil" do
+      assert GTFSRealtimeEnhanced.date(nil) == nil
+    end
+  end
+end

--- a/test/trip_updates/supervisor_test.exs
+++ b/test/trip_updates/supervisor_test.exs
@@ -1,0 +1,19 @@
+defmodule TripUpdates.SupervisorTest do
+  use ExUnit.Case, async: true
+
+  alias TripUpdates.Supervisor
+
+  describe "start_link/1" do
+    test "can start the application" do
+      assert {:ok, _pid} = Supervisor.start_link([])
+    end
+  end
+
+  describe "init/1" do
+    test "sets up the registry and pub-sub server" do
+      assert {:ok, {_sup_flags, children}} = Supervisor.init(:ok)
+
+      assert length(children) == 2
+    end
+  end
+end

--- a/test/trip_updates/trip_updates_pub_sub_test.exs
+++ b/test/trip_updates/trip_updates_pub_sub_test.exs
@@ -1,0 +1,124 @@
+defmodule TripUpdates.TripUpdatesPubSubTest do
+  use ExUnit.Case
+  alias TripUpdates.{StopTimeUpdate, TripUpdate, TripUpdatesPubSub}
+
+  @stop_time_update_with_waiver %StopTimeUpdate{
+    arrival_time: nil,
+    departure_time: nil,
+    cause_id: 12,
+    cause_description: nil,
+    remark: nil,
+    schedule_relationship: :SKIPPED,
+    status: nil,
+    stop_id: "s1",
+    stop_sequence: nil,
+    uncertainty: nil
+  }
+
+  @stop_time_update_without_waiver %StopTimeUpdate{
+    arrival_time: nil,
+    departure_time: nil,
+    cause_id: nil,
+    cause_description: nil,
+    remark: nil,
+    schedule_relationship: :SKIPPED,
+    status: nil,
+    stop_id: "s1",
+    stop_sequence: nil,
+    uncertainty: nil
+  }
+
+  @all_updates [
+    %TripUpdate{
+      start_date: nil,
+      start_time: nil,
+      stop_time_update: [
+        @stop_time_update_with_waiver,
+        @stop_time_update_with_waiver
+      ],
+      trip: %{
+        trip_id: "t1",
+        route_id: "2"
+      }
+    },
+    %TripUpdate{
+      start_date: nil,
+      start_time: nil,
+      stop_time_update: [
+        @stop_time_update_with_waiver,
+        @stop_time_update_without_waiver
+      ],
+      trip: %{
+        trip_id: "t1",
+        route_id: "3"
+      }
+    }
+  ]
+
+  @block_waivered_routes ["2"]
+
+  describe "start_link/1" do
+    test "starts the server" do
+      assert {:ok, _pid} = TripUpdatesPubSub.start_link(name: :start_link)
+    end
+  end
+
+  describe "subscribe/1" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry})
+      {:ok, pid} = TripUpdatesPubSub.start_link(name: :subscribe)
+      {:ok, pid: pid}
+    end
+
+    test "clients get existing route stats upon subscribing", %{pid: pid} do
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :block_waivered_routes, @block_waivered_routes)
+      end)
+
+      assert TripUpdatesPubSub.subscribe(pid) == @block_waivered_routes
+    end
+  end
+
+  describe "all" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry})
+      {:ok, pid} = TripUpdatesPubSub.start_link(name: :all)
+
+      :sys.replace_state(pid, fn state ->
+        Map.put(state, :block_waivered_routes, @block_waivered_routes)
+      end)
+
+      {:ok, pid: pid}
+    end
+
+    test "gets the blocked routes without subscribing to updates", %{pid: pid} do
+      assert TripUpdatesPubSub.all(pid) == @block_waivered_routes
+    end
+  end
+
+  describe "update_block_waivered_routes" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry})
+      {:ok, pid} = TripUpdatesPubSub.start_link(name: :update_block_waivered_routes)
+      {:ok, pid: pid}
+    end
+
+    test "updates list of blocked routes", %{pid: pid} do
+      assert :sys.get_state(pid) == %TripUpdatesPubSub{block_waivered_routes: []}
+
+      TripUpdatesPubSub.update_block_waivered_routes(@all_updates, pid)
+
+      assert :sys.get_state(pid) == %TripUpdatesPubSub{
+               block_waivered_routes: @block_waivered_routes
+             }
+    end
+
+    test "broadcasts blocked routes to subscribers", %{pid: pid} do
+      TripUpdatesPubSub.subscribe(pid)
+
+      TripUpdatesPubSub.update_block_waivered_routes(@all_updates, pid)
+
+      assert_receive {:block_waivered_routes, @block_waivered_routes}
+    end
+  end
+end

--- a/test/trip_updates/trip_updates_test.exs
+++ b/test/trip_updates/trip_updates_test.exs
@@ -1,0 +1,99 @@
+defmodule TripUpdates.TripUpdatesTest do
+  use ExUnit.Case
+
+  alias TripUpdates.{StopTimeUpdate, TripUpdate, TripUpdates}
+
+  @trip %{
+    trip_id: "t1",
+    route_id: "2"
+  }
+
+  @stop_time_update_with_waiver %StopTimeUpdate{
+    arrival_time: nil,
+    departure_time: nil,
+    cause_id: 12,
+    cause_description: nil,
+    remark: nil,
+    schedule_relationship: :SKIPPED,
+    status: nil,
+    stop_id: "s1",
+    stop_sequence: nil,
+    uncertainty: nil
+  }
+
+  @stop_time_update_without_waiver %StopTimeUpdate{
+    arrival_time: nil,
+    departure_time: nil,
+    cause_id: nil,
+    cause_description: nil,
+    remark: nil,
+    schedule_relationship: :SKIPPED,
+    status: nil,
+    stop_id: "s1",
+    stop_sequence: nil,
+    uncertainty: nil
+  }
+
+  @all_updates [
+    %TripUpdate{
+      start_date: nil,
+      start_time: nil,
+      stop_time_update: [
+        @stop_time_update_with_waiver,
+        @stop_time_update_with_waiver
+      ],
+      trip: @trip
+    },
+    %TripUpdate{
+      start_date: nil,
+      start_time: nil,
+      stop_time_update: [
+        @stop_time_update_with_waiver,
+        @stop_time_update_without_waiver
+      ],
+      trip: @trip
+    }
+  ]
+
+  describe "start_link/1" do
+    test "can start" do
+      start_supervised!(TripUpdates)
+    end
+  end
+
+  describe "handle_events/3" do
+    setup do
+      events = [@all_updates]
+
+      {:ok, events: events}
+    end
+
+    test "returns noreply", %{events: events} do
+      response = TripUpdates.handle_events(events, nil, %{})
+
+      assert response == {:noreply, [], %{}}
+    end
+
+    test "handles missing trips", %{events: events} do
+      response = TripUpdates.handle_events(events, nil, %{})
+
+      assert response == {:noreply, [], %{}}
+    end
+
+    test "trips with missing data", %{events: events} do
+      response = TripUpdates.handle_events(events, nil, %{})
+
+      assert response == {:noreply, [], %{}}
+    end
+  end
+
+  describe "backend implementation" do
+    test "handles reference info calls that come in after a timeout" do
+      state = %{}
+
+      response = TripUpdates.handle_info({make_ref(), %{}}, state)
+
+      assert response == {:noreply, [], state}
+    end
+  end
+end


### PR DESCRIPTION
Asana task: https://app.asana.com/0/1167196461144361/1204597186510078/f

Adds trip updates GTFS data source. Adds pubsub for same to get list of routes with block waivers. Adds to frontend.
![Screenshot 2023-06-28 at 9 31 09 AM](https://github.com/mbta/alerts_viewer/assets/17047573/c0b5c247-ef5a-4e3d-88c5-b3856ff6cd45)
