### PR TITLE
Display times in EST

### DIFF
--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -636,15 +636,9 @@ defmodule AlertsViewerWeb.CoreComponents do
   end
 
   @doc """
-  Renders a date-time in Eastern time using human-friendly formatting.
+  Renders a date-time using human-friendly formatting.
   """
   attr(:date_time, :map, required: true)
-
-  def date_time(%{date_time: %DateTime{}} = assigns) do
-    ~H"""
-    <%= friendly_date_time(@date_time |> DateTime.shift_zone!("America/New_York")) %>
-    """
-  end
 
   def date_time(assigns) do
     ~H"""

--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -636,9 +636,15 @@ defmodule AlertsViewerWeb.CoreComponents do
   end
 
   @doc """
-  Renders a date-time using human-friendly formatting.
+  Renders a date-time in Eastern time using human-friendly formatting.
   """
   attr(:date_time, :map, required: true)
+
+  def date_time(%{date_time: %DateTime{}} = assigns) do
+    ~H"""
+    <%= friendly_date_time(@date_time |> DateTime.shift_zone!("America/New_York")) %>
+    """
+  end
 
   def date_time(assigns) do
     ~H"""

--- a/lib/alerts_viewer_web/date_time_helpers.ex
+++ b/lib/alerts_viewer_web/date_time_helpers.ex
@@ -5,11 +5,11 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
 
   @doc """
   Return a human-friendly date-time string relative to "now".
-  Use the time if today, the month and day if this year, and the month and
+  Use the time (converted to EST) if today, the month and day if this year, and the month and
   year if a different year.
 
   iex> friendly_date_time(~U[2022-01-12 14:01:00.00Z], ~U[2022-01-12 15:02:00.00Z])
-  "2:01 PM"
+  "9:01 AM"
   iex> friendly_date_time(~U[2022-01-07 14:01:00.00Z], ~U[2022-01-12 15:02:00.00Z])
   "Jan 7"
   iex> friendly_date_time(~U[2021-12-07 14:01:00.00Z], ~U[2022-01-12 15:02:00.00Z])
@@ -24,7 +24,7 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
 
   def friendly_date_time(dt, now) do
     format = date_time_format(dt, now)
-    Calendar.strftime(dt, format)
+    Calendar.strftime(DateTime.shift_zone!(dt, "America/New_York"), format)
   end
 
   @spec date_time_format(DateTime.t(), DateTime.t()) :: String.t()


### PR DESCRIPTION
Displays all times in Eastern standard time. This affects everything that uses the date_time core component.

Asana Task: None, sorry, this was small so I just sorta did it.