### PR TITLE
fix: Apply z-index to table head instead of body

### DIFF
--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -551,7 +551,7 @@ defmodule AlertsViewerWeb.CoreComponents do
     ~H"""
     <div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
       <table class="mt-11 w-[40rem] sm:w-full">
-        <thead class={"text-left text-[0.8125rem] leading-6 text-zinc-500 #{if(@sticky, do: ~s(sticky top-0  bg-white), else: ~s())}"}>
+        <thead class={"text-left text-[0.8125rem] leading-6 text-zinc-500 z-10 #{if(@sticky, do: ~s(sticky top-0  bg-white), else: ~s())}"}>
           <tr>
             <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal"><%= col[:label] %></th>
             <th class="relative p-0 pb-4"><span class="sr-only"><%= gettext("Actions") %></span></th>
@@ -560,7 +560,7 @@ defmodule AlertsViewerWeb.CoreComponents do
         <tbody
           id={@id}
           phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
-          class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700 -z-10"
+          class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700"
         >
           <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class="group hover:bg-zinc-50">
             <td


### PR DESCRIPTION
No ticket, this is just something I noticed when working with the site.

At least on Safari this seems to work better for me (though I don't know why it should).

Before:

<img width="440" alt="Screenshot 2023-07-17 at 11 05 52" src="https://github.com/mbta/alerts_viewer/assets/42339/d10bda2b-54b3-49f1-bba9-d387aaf6d33c">

After:

<img width="448" alt="Screenshot 2023-07-17 at 11 05 59" src="https://github.com/mbta/alerts_viewer/assets/42339/b5b428b5-e4f9-4189-bfe7-5ecaa9e59bcf">
