### PR TITLE
feat: Max value bus delay algorithms for adherence and headway

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,8 @@ config :alerts_viewer,
     AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousHeadwayComponent,
     AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousMinusScheduledHeadwayComponent,
     AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusScheduledHeadwayComponent,
-    AlertsViewer.DelayAlertAlgorithm.MaxAdherenceComponent
+    AlertsViewer.DelayAlertAlgorithm.MaxAdherenceComponent,
+    AlertsViewer.DelayAlertAlgorithm.MaxInstantaneousMinusScheduledHeadwayComponent
   ],
   swiftly_authorization_key: {:system, "SWIFTLY_AUTHORIZATION_KEY"},
   swiftly_realtime_vehicles_url: {:system, "SWIFTLY_REALTIME_VEHICLES_URL"},

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,8 @@ config :alerts_viewer,
     AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousHeadwayComponent,
     AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousHeadwayComponent,
     AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousMinusScheduledHeadwayComponent,
-    AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusScheduledHeadwayComponent
+    AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusScheduledHeadwayComponent,
+    AlertsViewer.DelayAlertAlgorithm.MaxAdherenceComponent
   ],
   swiftly_authorization_key: {:system, "SWIFTLY_AUTHORIZATION_KEY"},
   swiftly_realtime_vehicles_url: {:system, "SWIFTLY_REALTIME_VEHICLES_URL"},

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/base_algorithm_components/one_slider_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/base_algorithm_components/one_slider_component.ex
@@ -1,5 +1,10 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent do
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    snapshot_min = Keyword.get(opts, :snapshot_min)
+    snapshot_max = Keyword.get(opts, :snapshot_max)
+    snapshot_interval = Keyword.get(opts, :snapshot_interval)
+    min_value = Keyword.get(opts, :min_value)
+
     quote do
       @moduledoc """
       Component for shared functions between algorithm components with one slider.
@@ -12,13 +17,18 @@ defmodule AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComp
 
       alias Routes.{Route, RouteStats}
 
-      @snapshot_min 50
-      @snapshot_max 1500
-      @snapshot_interval 50
-
       @impl true
       def mount(socket) do
-        {:ok, assign(socket, min_value: 1200)}
+        socket =
+          assign(
+            socket,
+            snapshot_min: unquote(snapshot_min),
+            snapshot_max: unquote(snapshot_max),
+            snapshot_interval: unquote(snapshot_interval),
+            min_value: unquote(min_value)
+          )
+
+        {:ok, socket}
       end
 
       @impl true
@@ -50,27 +60,6 @@ defmodule AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComp
 
         {:noreply, assign(socket, min_value: min_value)}
       end
-
-      @impl true
-      def snapshot(routes, stats_by_route) do
-        @snapshot_min..@snapshot_max//@snapshot_interval
-        |> Enum.to_list()
-        |> Enum.map(fn value ->
-          routes_with_recommended_alerts =
-            Enum.filter(
-              routes,
-              &recommending_alert?(&1, stats_by_route, value)
-            )
-
-          [
-            parameters: %{value: value},
-            routes_with_recommended_alerts: routes_with_recommended_alerts
-          ]
-        end)
-      end
-
-      defp snapshot_min, do: @snapshot_min
-      defp snapshot_max, do: @snapshot_max
     end
   end
 end

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/max_adherence_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/max_adherence_component.ex
@@ -1,0 +1,63 @@
+defmodule AlertsViewer.DelayAlertAlgorithm.MaxAdherenceComponent do
+  @moduledoc """
+  Component for controlling the Max adherence delay alert recommendation algorithm.
+  """
+
+  @snapshot_min 0
+  @snapshot_max 100
+  @snapshot_interval 5
+  @default_min_value 15
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex space-x-16 items-center">
+      <.controls_form phx-change="update-controls" phx-target={@myself}>
+        <.input
+          type="range"
+          name="min_value"
+          value={@min_value}
+          min={0}
+          max={100}
+          label="Threshold (minutes)"
+        />
+        <span class="ml-2">
+          <%= @min_value %>
+        </span>
+      </.controls_form>
+      <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
+    </div>
+    """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
+  end
+
+  @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::
+          boolean()
+  defp recommending_alert?(route, stats_by_route, threshold_in_minutes) do
+    max = RouteStats.max_schedule_adherence(stats_by_route, route)
+    !is_nil(max) and max >= threshold_in_minutes * 60
+  end
+end

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/max_instantaneous_minus_scheduled_headway_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/max_instantaneous_minus_scheduled_headway_component.ex
@@ -1,0 +1,63 @@
+defmodule AlertsViewer.DelayAlertAlgorithm.MaxInstantaneousMinusScheduledHeadwayComponent do
+  @moduledoc """
+  Component for controlling the Max instantaneos minus scheduled headway delay alert recommendation algorithm.
+  """
+
+  @snapshot_min 0
+  @snapshot_max 100
+  @snapshot_interval 5
+  @default_min_value 15
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex space-x-16 items-center">
+      <.controls_form phx-change="update-controls" phx-target={@myself}>
+        <.input
+          type="range"
+          name="min_value"
+          value={@min_value}
+          min={0}
+          max={100}
+          label="Threshold (minutes)"
+        />
+        <span class="ml-2">
+          <%= @min_value %>
+        </span>
+      </.controls_form>
+      <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
+    </div>
+    """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
+  end
+
+  @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::
+          boolean()
+  defp recommending_alert?(route, stats_by_route, threshold_in_minutes) do
+    max = RouteStats.max_instantaneous_minus_scheduled_headway(stats_by_route, route)
+    !is_nil(max) and max >= threshold_in_minutes * 60
+  end
+end

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/median_adherence_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/median_adherence_component.ex
@@ -1,9 +1,18 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.MedianAdherenceComponent do
-  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent
-
   @moduledoc """
   Component for controlling the Median delay alert recommendation algorithm.
   """
+
+  @snapshot_min 50
+  @snapshot_max 1500
+  @snapshot_interval 50
+  @default_min_value 1200
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
 
   @impl true
   def render(assigns) do
@@ -14,8 +23,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAdherenceComponent do
           type="range"
           name="min_value"
           value={@min_value}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Median"
         />
         <span class="ml-2">
@@ -25,6 +34,24 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAdherenceComponent do
       <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
     </div>
     """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
   end
 
   @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/median_and_standard_deviation_component_adherence.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/median_and_standard_deviation_component_adherence.ex
@@ -16,7 +16,17 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAndStandardDeviationAdherenceCo
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, min_std_val: 1200, min_median_val: 1200)}
+    socket =
+      assign(
+        socket,
+        min_std_val: 1200,
+        min_median_val: 1200,
+        snapshot_min: @snapshot_min,
+        snapshot_max: @snapshot_max,
+        snapshot_interval: @snapshot_interval
+      )
+
+    {:ok, socket}
   end
 
   @impl true
@@ -51,8 +61,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAndStandardDeviationAdherenceCo
           type="range"
           name="min_median_val"
           value={@min_median_val}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Median Value"
         />
         <span class="ml-1">
@@ -63,8 +73,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAndStandardDeviationAdherenceCo
           type="range"
           name="min_std_val"
           value={@min_std_val}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Standard Deviation"
         />
         <span class="ml-1">
@@ -126,7 +136,4 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianAndStandardDeviationAdherenceCo
     std = RouteStats.standard_deviation_of_schedule_adherence(stats_by_route, route)
     !is_nil(median) and median >= min_median_val && !is_nil(std) and std >= min_std_val
   end
-
-  defp snapshot_min, do: @snapshot_min
-  defp snapshot_max, do: @snapshot_max
 end

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/median_instantaneous_headway_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/median_instantaneous_headway_component.ex
@@ -1,9 +1,18 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousHeadwayComponent do
-  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent
-
   @moduledoc """
   Component for controlling the Median delay alert recommendation algorithm.
   """
+
+  @snapshot_min 50
+  @snapshot_max 1500
+  @snapshot_interval 50
+  @default_min_value 1200
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
 
   @impl true
   def render(assigns) do
@@ -14,8 +23,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousHeadwayComponent d
           type="range"
           name="min_value"
           value={@min_value}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Median Instantaneous Headway"
         />
         <span class="ml-2">
@@ -25,6 +34,24 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousHeadwayComponent d
       <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
     </div>
     """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
   end
 
   @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/median_instantaneous_minus_scheduled_headway_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/median_instantaneous_minus_scheduled_headway_component.ex
@@ -1,9 +1,18 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousMinusScheduledHeadwayComponent do
-  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent
-
   @moduledoc """
   Component for controlling the Median delay alert recommendation algorithm.
   """
+
+  @snapshot_min 50
+  @snapshot_max 1500
+  @snapshot_interval 50
+  @default_min_value 1200
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
 
   @impl true
   def render(assigns) do
@@ -14,8 +23,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousMinusScheduledHead
           type="range"
           name="min_value"
           value={@min_value}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Median Instantaneous - Scheduled Headway"
         />
         <span class="ml-2">
@@ -25,6 +34,24 @@ defmodule AlertsViewer.DelayAlertAlgorithm.MedianInstantaneousMinusScheduledHead
       <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
     </div>
     """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
   end
 
   @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/standard_deviation_instantaneous_headway_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/standard_deviation_instantaneous_headway_component.ex
@@ -1,9 +1,18 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousHeadwayComponent do
-  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent
-
   @moduledoc """
   Component for controlling the standard deviation delay alert recommendation algorithm.
   """
+
+  @snapshot_min 50
+  @snapshot_max 1500
+  @snapshot_interval 50
+  @default_min_value 1200
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
 
   @impl true
   def render(assigns) do
@@ -14,8 +23,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousHeadway
           type="range"
           name="min_value"
           value={@min_value}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Standard Deviation of Instantaneous Headway"
         />
         <span class="ml-2">
@@ -25,6 +34,24 @@ defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousHeadway
       <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
     </div>
     """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
   end
 
   @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::

--- a/lib/alerts_viewer_web/live/delay_alert_algorithm/standard_deviation_instantaneous_minus_scheduled_headway_component.ex
+++ b/lib/alerts_viewer_web/live/delay_alert_algorithm/standard_deviation_instantaneous_minus_scheduled_headway_component.ex
@@ -1,9 +1,18 @@
 defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusScheduledHeadwayComponent do
-  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent
-
   @moduledoc """
   Component for controlling the standard deviation delay alert recommendation algorithm.
   """
+
+  @snapshot_min 50
+  @snapshot_max 1500
+  @snapshot_interval 50
+  @default_min_value 1200
+
+  use AlertsViewer.DelayAlertAlgorithm.BaseAlgorithmComponents.OneSliderComponent,
+    snapshot_min: @snapshot_min,
+    snapshot_max: @snapshot_max,
+    snapshot_interval: @snapshot_interval,
+    min_value: @default_min_value
 
   @impl true
   def render(assigns) do
@@ -14,8 +23,8 @@ defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusSc
           type="range"
           name="min_value"
           value={@min_value}
-          min={snapshot_min()}
-          max={snapshot_max()}
+          min={@snapshot_min}
+          max={@snapshot_max}
           label="Minumum Standard Deviation of Instantaneous - Scheduled Headway"
         />
         <span class="ml-2">
@@ -25,6 +34,24 @@ defmodule AlertsViewer.DelayAlertAlgorithm.StandardDeviationInstantaneousMinusSc
       <SnapshotButtonComponent.snapshot_button module_name={__MODULE__} />
     </div>
     """
+  end
+
+  @impl true
+  def snapshot(routes, stats_by_route) do
+    @snapshot_min..@snapshot_max//@snapshot_interval
+    |> Enum.to_list()
+    |> Enum.map(fn value ->
+      routes_with_recommended_alerts =
+        Enum.filter(
+          routes,
+          &recommending_alert?(&1, stats_by_route, value)
+        )
+
+      [
+        parameters: %{value: value},
+        routes_with_recommended_alerts: routes_with_recommended_alerts
+      ]
+    end)
   end
 
   @spec recommending_alert?(Route.t(), RouteStats.stats_by_route(), non_neg_integer()) ::

--- a/lib/routes/route_stats.ex
+++ b/lib/routes/route_stats.ex
@@ -205,6 +205,21 @@ defmodule Routes.RouteStats do
   end
 
   ####### Algorithms for Instantaneous Minus Scheduled Headway
+  @spec max_instantaneous_minus_scheduled_headway(t()) :: number() | nil
+  @spec max_instantaneous_minus_scheduled_headway(stats_by_route(), Route.t()) ::
+          number() | nil
+  def max_instantaneous_minus_scheduled_headway(route_stats) do
+    route_stats
+    |> vehicles_instantaneous_minus_scheduled_headway_secs()
+    |> Enum.max(fn -> nil end)
+  end
+
+  def max_instantaneous_minus_scheduled_headway(stats_by_route, route) do
+    stats_by_route
+    |> stats_for_route(route)
+    |> max_instantaneous_minus_scheduled_headway()
+  end
+
   @spec median_instantaneous_minus_scheduled_headway(t()) :: number() | nil
   @spec median_instantaneous_minus_scheduled_headway(stats_by_route(), Route.t()) ::
           number() | nil

--- a/lib/routes/route_stats.ex
+++ b/lib/routes/route_stats.ex
@@ -92,6 +92,20 @@ defmodule Routes.RouteStats do
   end
 
   ############# Algorithms for Schedule Adherence
+  @spec max_schedule_adherence(t()) :: number() | nil
+  @spec max_schedule_adherence(stats_by_route(), Route.t()) :: number() | nil
+  def max_schedule_adherence(route_stats) do
+    route_stats
+    |> vehicles_schedule_adherence_secs()
+    |> Enum.max(fn -> nil end)
+  end
+
+  def max_schedule_adherence(stats_by_route, route) do
+    stats_by_route
+    |> stats_for_route(route)
+    |> max_schedule_adherence()
+  end
+
   @spec median_schedule_adherence(t()) :: number() | nil
   @spec median_schedule_adherence(stats_by_route(), Route.t()) :: number() | nil
   def median_schedule_adherence(route_stats) do

--- a/test/routes/route_stats_test.exs
+++ b/test/routes/route_stats_test.exs
@@ -126,6 +126,26 @@ defmodule Routes.RouteStatsTest do
     end
   end
 
+  describe "max_schedule_adherence" do
+    test "returns the median schedule adherence for all vehicles" do
+      route_stats = %RouteStats{id: "1", vehicles_schedule_adherence_secs: [1, 2, 3]}
+
+      assert RouteStats.max_schedule_adherence(route_stats) == 3
+    end
+
+    test "returns nil if no vehicles_schedule_adherence_secs values" do
+      route_stats = %RouteStats{id: "1", vehicles_schedule_adherence_secs: []}
+
+      assert RouteStats.max_schedule_adherence(route_stats) == nil
+    end
+
+    test "accepts stats_by_route and a route" do
+      stats_by_route = %{"1" => %RouteStats{id: "1", vehicles_schedule_adherence_secs: [1, 2, 3]}}
+
+      assert RouteStats.max_schedule_adherence(stats_by_route, %Route{id: "1"}) == 3
+    end
+  end
+
   describe "standard_deviation_of_schedule_adherence rounded to 1 place" do
     test "" do
       route_stats = %RouteStats{id: "1", vehicles_schedule_adherence_secs: [1, 2]}

--- a/test/routes/route_stats_test.exs
+++ b/test/routes/route_stats_test.exs
@@ -257,6 +257,36 @@ defmodule Routes.RouteStatsTest do
     end
   end
 
+  describe "max_instantaneous_minus_scheduled_headway" do
+    test "returns the max instantaneous minus scheduled headway for all vehicles" do
+      route_stats = %RouteStats{
+        id: "1",
+        vehicles_instantaneous_minus_scheduled_headway_secs: [1, 2, 3]
+      }
+
+      assert RouteStats.max_instantaneous_minus_scheduled_headway(route_stats) == 3
+    end
+
+    test "returns nil if no vehicles_instantaneous_minus_scheduled_headway_secs values" do
+      route_stats = %RouteStats{id: "1", vehicles_instantaneous_minus_scheduled_headway_secs: []}
+
+      assert RouteStats.max_instantaneous_minus_scheduled_headway(route_stats) == nil
+    end
+
+    test "accepts stats_by_route and a route" do
+      stats_by_route = %{
+        "1" => %RouteStats{
+          id: "1",
+          vehicles_instantaneous_minus_scheduled_headway_secs: [1, 2, 3]
+        }
+      }
+
+      assert RouteStats.max_instantaneous_minus_scheduled_headway(stats_by_route, %Route{
+               id: "1"
+             }) == 3
+    end
+  end
+
   describe "median_instantaneous_minus_scheduled_headway" do
     test "returns the median instantaneous minus scheduled headway for all vehicles rounded to 1 place" do
       route_stats = %RouteStats{


### PR DESCRIPTION
Asana ticket: [Bus delay algorithms: peak/max values of adherence and/or headways](https://app.asana.com/0/1204819229687089/1205010427056660)

2 new components:
- MaxAdherenceComponent
- MaxInstantaneousMinusScheduledHeadwayComponent

Also, an initial refactor: OneSliderComponent allows any slider values
This means that the snapshot function is currently duplicated in every
component, but I'm putting that off for the moment because I think we
might end up changing how that works when we build out data logging.
(I.e., I'm wondering if snapshots will go away to be replaced by logging.)