### PR TITLE
ci: Create Asana Attachment GitHub action

### DIFF
--- a/.github/workflows/create-asana-attachment.yaml
+++ b/.github/workflows/create-asana-attachment.yaml
@@ -1,0 +1,18 @@
+name: Create Asana Attachment
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name: Create pull request attachments on Asana tasks
+    steps:
+      - name: Create pull request attachments
+        uses: Asana/create-app-attachment-github-action@latest
+        id: postAttachment
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+      - name: Log output status
+        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"


### PR DESCRIPTION
This will attach GitHub PR links to our Asana tickets.

Ironically, no Asana ticket for this. We have this set up in https://github.com/mbta/alerts_concierge but I realized not here yet.