### PR TITLE
feature: Display alert durations in friendly hours or minutes

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -255,12 +255,11 @@ defmodule Alerts.Alert do
     do: matches_route(alert, route_id) and matches_effect(alert, effect)
 
   @doc """
-  Duration of alert in hours, to 1 decimal point
+  Duration of alert in seconds
   """
-  @spec alert_duration(t()) :: float()
+  @spec alert_duration(t()) :: integer()
   def alert_duration(alert, current_time \\ DateTime.now!("America/New_York")) do
-    (DateTime.diff(current_time, alert.created_at) / 3600)
-    |> Float.round(1)
+    DateTime.diff(current_time, alert.created_at)
   end
 
   @spec activities_inclued_facility_activities(informed_entity()) :: boolean()

--- a/lib/alerts_viewer_web/date_time_helpers.ex
+++ b/lib/alerts_viewer_web/date_time_helpers.ex
@@ -3,6 +3,9 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
   Utility functions for formatting dates and times.
   """
 
+  @one_minute_in_seconds 60
+  @one_hour_in_seconds @one_minute_in_seconds * 60
+
   @doc """
   Return a human-friendly date-time string relative to "now".
   Use the time (converted to EST) if today, the month and day if this year, and the month and
@@ -27,6 +30,34 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
     format = date_time_format(dt, now)
     Calendar.strftime(DateTime.shift_zone!(dt, "America/New_York"), format)
   end
+
+  @doc """
+  Return a human-friendly time duration string. Display in hours, rounded down,
+  if greater than 1 hour, otherwise in minutes rounded down.
+
+  iex> friendly_duration(7400)
+  "2 hours"
+  iex> friendly_duration(120)
+  "2 minutes"
+  iex> friendly_duration(5400)
+  "1 hour"
+  iex> friendly_duration(70)
+  "1 minute"
+  """
+  @spec friendly_duration(integer()) :: String.t()
+  def friendly_duration(time_in_secs)
+      when time_in_secs >= @one_hour_in_seconds and time_in_secs < 2 * @one_hour_in_seconds,
+      do: "1 hour"
+
+  def friendly_duration(time_in_secs) when time_in_secs >= @one_hour_in_seconds,
+    do: "#{floor(time_in_secs / @one_hour_in_seconds)} hours"
+
+  def friendly_duration(time_in_secs)
+      when time_in_secs >= @one_minute_in_seconds and time_in_secs < 2 * @one_minute_in_seconds,
+      do: "1 minute"
+
+  def friendly_duration(time_in_secs),
+    do: "#{floor(time_in_secs / @one_minute_in_seconds)} minutes"
 
   @doc """
   Change seconds into minutes, rounded to an integer

--- a/lib/alerts_viewer_web/date_time_helpers.ex
+++ b/lib/alerts_viewer_web/date_time_helpers.ex
@@ -20,17 +20,13 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
   @spec friendly_date_time(DateTime.t() | nil) :: String.t()
   @spec friendly_date_time(DateTime.t() | nil, DateTime.t()) :: String.t()
   def friendly_date_time(dt, now \\ DateTime.now!("America/New_York"))
+
   def friendly_date_time(nil, _now), do: ""
 
   def friendly_date_time(dt, now) do
     format = date_time_format(dt, now)
     Calendar.strftime(DateTime.shift_zone!(dt, "America/New_York"), format)
   end
-
-  @spec date_time_format(DateTime.t(), DateTime.t()) :: String.t()
-  defp date_time_format(dt, now) when dt.day == now.day, do: "%-I:%M %p"
-  defp date_time_format(dt, now) when dt.year == now.year, do: "%b %-d"
-  defp date_time_format(_, _), do: "%b %Y"
 
   @doc """
   Change seconds into minutes, rounded to an integer
@@ -52,4 +48,9 @@ defmodule AlertsViewerWeb.DateTimeHelpers do
   def seconds_to_minutes(seconds) do
     round(seconds / 60)
   end
+
+  @spec date_time_format(DateTime.t(), DateTime.t()) :: String.t()
+  defp date_time_format(dt, now) when dt.day == now.day, do: "%-I:%M %p"
+  defp date_time_format(dt, now) when dt.year == now.year, do: "%b %-d"
+  defp date_time_format(_, _), do: "%b %Y"
 end

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -59,7 +59,10 @@
     </span>
   </:col>
   <:col :let={route} label="Alert Duration (hours)">
-    <%= Enum.map(@alerts_by_route[route], &Alert.alert_duration(&1)) |> Enum.join(", ") %>
+    <%= @alerts_by_route[route]
+    |> Enum.max_by(&Alert.alert_duration/1)
+    |> Alert.alert_duration()
+    |> friendly_duration() %>
   </:col>
   <:col :let={route} label="Recommending Alert Closure">
     <span

--- a/lib/alerts_viewer_web/live/bus_live.html.heex
+++ b/lib/alerts_viewer_web/live/bus_live.html.heex
@@ -144,7 +144,10 @@
     >
       <div>
         <span class="absolute hidden group-hover:flex -left-2 -top-2 -translate-y-full w-36 px-2 py-1 bg-gray-700 rounded-lg text-center text-white text-sm z-50">
-          Open for <%= Alert.alert_duration(hd(@alerts_by_route[route.id])) %> hours
+          Open for <%= @alerts_by_route[route.id]
+          |> hd()
+          |> Alert.alert_duration()
+          |> friendly_duration() %>
         </span>
         <.alert_icon />
       </div>

--- a/test/alerts/alert_test.exs
+++ b/test/alerts/alert_test.exs
@@ -171,7 +171,7 @@ defmodule Alerts.AlertTest do
   end
 
   describe "alert_duration/2" do
-    test "returns duration of alert in hours" do
+    test "returns duration of alert in seconds" do
       current_time = DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York")
 
       alert = %Alert{
@@ -184,7 +184,7 @@ defmodule Alerts.AlertTest do
         ]
       }
 
-      assert Alert.alert_duration(alert, current_time) == 1.5
+      assert Alert.alert_duration(alert, current_time) == 5400
     end
   end
 end


### PR DESCRIPTION
One tiny step towards [Tweak /open-delay-alerts columns and styling](https://app.asana.com/0/1167196461144361/1205250462129251). I started playing with it just for fun but figured it didn't hurt to throw it in.

Round down to the nearest hour or minute.