### PR TITLE
Rearranges alerts_to_close_page

### DIFF
--- a/lib/alerts/alert.ex
+++ b/lib/alerts/alert.ex
@@ -262,6 +262,17 @@ defmodule Alerts.Alert do
     DateTime.diff(current_time, alert.created_at)
   end
 
+  @spec route_ids(t()) :: [String.t()]
+  def route_ids(alert) do
+    alert.informed_entity
+    |> Enum.map(&route_ids_from_informed_entity/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @spec route_ids_from_informed_entity(informed_entity()) :: boolean() | nil
+  defp route_ids_from_informed_entity(%{route: route}), do: route
+  defp route_ids_from_informed_entity(_), do: nil
+
   @spec activities_inclued_facility_activities(informed_entity()) :: boolean()
   defp activities_inclued_facility_activities(%{activities: activities}),
     do: Enum.any?(activities, &Enum.member?(@facility_activies, &1))

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.ex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.ex
@@ -37,8 +37,7 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
         bus_routes: bus_routes,
         block_waivered_routes: block_waivered_routes,
         sorted_alerts: sorted_alerts,
-        alerts_by_route: Alerts.by_route(sorted_alerts),
-        routes_with_recommended_closures: []
+        alerts_with_recommended_closures: []
       )
 
     {:ok, socket}
@@ -64,12 +63,12 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
 
   @impl true
   def handle_info(
-        {:updated_routes_with_recommended_closures, routes_with_recommended_closures},
+        {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures},
         socket
       ) do
     socket =
       assign(socket,
-        routes_with_recommended_closures: routes_with_recommended_closures
+        alerts_with_recommended_closures: alerts_with_recommended_closures
       )
 
     {:noreply, socket}

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.ex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.ex
@@ -81,6 +81,15 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
     {:noreply, assign(socket, current_algorithm: current_algorithm)}
   end
 
+  @spec route_names_from_alert(Alert.t(), [Route.t()]) :: [String.t()]
+  def route_names_from_alert(alert, bus_routes) do
+    alert
+    |> Alert.route_ids()
+    |> Enum.map(&Routes.get_by_id(bus_routes, &1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&Route.name/1)
+  end
+
   @spec sorted_alerts([Alert.t()]) :: [Alert.t()]
   defp sorted_alerts(alerts) do
     alerts
@@ -90,22 +99,6 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
       & &1.created_at,
       {:asc, DateTime}
     )
-  end
-
-  @spec route_ids_from_alert(Alert.t()) :: [String.t()]
-  def route_ids_from_alert(alert) do
-    Enum.map(alert.informed_entity, fn entity ->
-      entity.route
-    end)
-  end
-
-  @spec route_names_from_alert(Alert.t(), [Route.t()]) :: [String.t()]
-  def route_names_from_alert(alert, bus_routes) do
-    alert
-    |> route_ids_from_alert()
-    |> Enum.map(&Routes.get_by_id(bus_routes, &1))
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map(&Route.name/1)
   end
 
   @spec delay_alert?(Route.t(), [Alert.t()]) :: boolean()

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.ex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.ex
@@ -25,7 +25,7 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
 
     stats_by_route = if(connected?(socket), do: RouteStatsPubSub.subscribe(), else: %{})
 
-    alerts_by_route = alerts_by_route(alerts, bus_routes)
+    sorted_alerts = sorted_alerts(alerts)
 
     block_waivered_routes = if(connected?(socket), do: TripUpdatesPubSub.subscribe(), else: [])
 
@@ -36,7 +36,8 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
         stats_by_route: stats_by_route,
         bus_routes: bus_routes,
         block_waivered_routes: block_waivered_routes,
-        alerts_by_route: alerts_by_route,
+        sorted_alerts: sorted_alerts,
+        alerts_by_route: Alerts.by_route(sorted_alerts),
         routes_with_recommended_closures: []
       )
 
@@ -45,8 +46,10 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
 
   @impl true
   def handle_info({:alerts, alerts}, socket) do
-    alerts_by_route = alerts_by_route(alerts, socket.assigns.bus_routes)
-    {:noreply, assign(socket, alerts_by_route: alerts_by_route)}
+    sorted_alerts = sorted_alerts(alerts)
+
+    {:noreply,
+     assign(socket, sorted_alerts: sorted_alerts, alerts_by_route: Alerts.by_route(sorted_alerts))}
   end
 
   @impl true
@@ -78,26 +81,31 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
     {:noreply, assign(socket, current_algorithm: current_algorithm)}
   end
 
-  @spec alerts_by_route([Alert.t()], [Route.t()]) :: keyword([Alert.t()])
-  defp alerts_by_route(alerts, bus_routes) do
-    route_ids = Enum.map(bus_routes, & &1.id)
-
+  @spec sorted_alerts([Alert.t()]) :: [Alert.t()]
+  defp sorted_alerts(alerts) do
     alerts
     |> filtered_by_bus()
     |> filtered_by_delay_type()
-    |> Alerts.by_route()
-    |> Enum.filter(fn {route_id, _alerts} ->
-      Enum.member?(route_ids, route_id)
-    end)
-    |> Enum.map(fn {route_id, alerts} -> {String.to_atom(route_id), alerts} end)
     |> Enum.sort_by(
-      fn {_route_id, alerts} ->
-        alerts
-        |> Enum.map(& &1.created_at)
-        |> Enum.max(DateTime)
-      end,
-      :asc
+      & &1.created_at,
+      {:asc, DateTime}
     )
+  end
+
+  @spec route_ids_from_alert(Alert.t()) :: [String.t()]
+  def route_ids_from_alert(alert) do
+    Enum.map(alert.informed_entity, fn entity ->
+      entity.route
+    end)
+  end
+
+  @spec route_names_from_alert(Alert.t(), [Route.t()]) :: [String.t()]
+  def route_names_from_alert(alert, bus_routes) do
+    alert
+    |> route_ids_from_alert()
+    |> Enum.map(&Routes.get_by_id(bus_routes, &1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&Route.name/1)
   end
 
   @spec delay_alert?(Route.t(), [Alert.t()]) :: boolean()

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -30,57 +30,62 @@
   </:col>
   <:col :let={alert} label="Median Adherence (minutes)">
     <%= alert
-    |> route_ids_from_alert()
+    |> Alert.route_ids()
     |> Enum.map(fn route_id ->
       @stats_by_route
       |> RouteStats.median_schedule_adherence(route_id)
       |> seconds_to_minutes()
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Peak Adherence (minutes)">
     <%= alert
-    |> route_ids_from_alert()
+    |> Alert.route_ids()
     |> Enum.map(fn route_id ->
       @stats_by_route
       |> RouteStats.max_schedule_adherence(route_id)
       |> seconds_to_minutes()
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Median Instantaneous Headway (minutes)">
     <%= alert
-    |> route_ids_from_alert()
+    |> Alert.route_ids()
     |> Enum.map(fn route_id ->
       @stats_by_route
       |> RouteStats.median_instantaneous_headway(route_id)
       |> seconds_to_minutes()
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Median Headway Deviation (minutes)">
     <%= alert
-    |> route_ids_from_alert()
+    |> Alert.route_ids()
     |> Enum.map(fn route_id ->
       @stats_by_route
       |> RouteStats.median_headway_deviation(route_id)
       |> seconds_to_minutes()
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Peak Headway Deviation (minutes)">
     <%= alert
-    |> route_ids_from_alert()
+    |> Alert.route_ids()
     |> Enum.map(fn route_id ->
       @stats_by_route
       |> RouteStats.max_headway_deviation(route_id)
       |> seconds_to_minutes()
     end)
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Route has Cancelled Trip">
     <span :if={
-      length(@block_waivered_routes -- route_ids_from_alert(alert)) <
+      length(@block_waivered_routes -- Alert.route_ids(alert)) <
         length(@block_waivered_routes)
     }>
       ❌
@@ -93,16 +98,20 @@
   <:col :let={alert} label="Recommending Alert Closure">
     <span
       :if={
-        length(@routes_with_recommended_closures -- route_ids_from_alert(alert)) <
-          length(@routes_with_recommended_closures)
+        Enum.any?(
+          Alert.route_ids(alert),
+          &Enum.member?(@routes_with_recommended_closures, &1)
+        )
       }
       class="text-red-600 font-bold"
     >
       Y
     </span>
     <span :if={
-      length(@routes_with_recommended_closures -- route_ids_from_alert(alert)) ==
-        length(@routes_with_recommended_closures)
+      !Enum.any?(
+        Alert.route_ids(alert),
+        &Enum.member?(@routes_with_recommended_closures, &1)
+      )
     }>
       N
     </span>

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -21,57 +21,89 @@
   />
 </div>
 
-<.table id="bus_alerts" sticky={true} rows={Keyword.keys(@alerts_by_route)}>
-  <:col :let={route} label="Route Name">
-    <%= Routes.get_by_id(@bus_routes, Atom.to_string(route)) |> Route.name() %>
+<.table id="bus_alerts" sticky={true} rows={@sorted_alerts}>
+  <:col :let={alert} label="Alert Id (sorted by duration)">
+    <%= alert.id %>
   </:col>
-  <:col :let={route} label="Alert Ids (sorted by duration)">
-    <%= @alerts_by_route[route] |> Enum.map(& &1.id) |> Enum.join(", ") %>
+  <:col :let={alert} label="Route Names">
+    <.informed_entity_icons entities={route_names_from_alert(alert, @bus_routes)} />
   </:col>
-  <:col :let={route} label="Median Adherence (minutes)">
-    <%= @stats_by_route
-    |> RouteStats.median_schedule_adherence(Atom.to_string(route))
-    |> seconds_to_minutes() %>
+  <:col :let={alert} label="Median Adherence (minutes)">
+    <%= alert
+    |> route_ids_from_alert()
+    |> Enum.map(fn route_id ->
+      @stats_by_route
+      |> RouteStats.median_schedule_adherence(route_id)
+      |> seconds_to_minutes()
+    end)
+    |> Enum.join(",") %>
   </:col>
-  <:col :let={route} label="Peak Adherence (minutes)">
-    <%= @stats_by_route
-    |> RouteStats.max_schedule_adherence(Atom.to_string(route))
-    |> seconds_to_minutes() %>
+  <:col :let={alert} label="Peak Adherence (minutes)">
+    <%= alert
+    |> route_ids_from_alert()
+    |> Enum.map(fn route_id ->
+      @stats_by_route
+      |> RouteStats.max_schedule_adherence(route_id)
+      |> seconds_to_minutes()
+    end)
+    |> Enum.join(",") %>
   </:col>
-  <:col :let={route} label="Median Instantaneous Headway (minutes)">
-    <%= @stats_by_route
-    |> RouteStats.median_instantaneous_headway(Atom.to_string(route))
-    |> seconds_to_minutes() %>
+  <:col :let={alert} label="Median Instantaneous Headway (minutes)">
+    <%= alert
+    |> route_ids_from_alert()
+    |> Enum.map(fn route_id ->
+      @stats_by_route
+      |> RouteStats.median_instantaneous_headway(route_id)
+      |> seconds_to_minutes()
+    end)
+    |> Enum.join(",") %>
   </:col>
-  <:col :let={route} label="Median Headway Deviation (minutes)">
-    <%= @stats_by_route
-    |> RouteStats.median_headway_deviation(Atom.to_string(route))
-    |> seconds_to_minutes() %>
+  <:col :let={alert} label="Median Headway Deviation (minutes)">
+    <%= alert
+    |> route_ids_from_alert()
+    |> Enum.map(fn route_id ->
+      @stats_by_route
+      |> RouteStats.median_headway_deviation(route_id)
+      |> seconds_to_minutes()
+    end)
+    |> Enum.join(",") %>
   </:col>
-  <:col :let={route} label="Peak Headway Deviation (minutes)">
-    <%= @stats_by_route
-    |> RouteStats.max_headway_deviation(Atom.to_string(route))
-    |> seconds_to_minutes() %>
+  <:col :let={alert} label="Peak Headway Deviation (minutes)">
+    <%= alert
+    |> route_ids_from_alert()
+    |> Enum.map(fn route_id ->
+      @stats_by_route
+      |> RouteStats.max_headway_deviation(route_id)
+      |> seconds_to_minutes()
+    end)
+    |> Enum.join(",") %>
   </:col>
-  <:col :let={route} label="Route has Cancelled Trip">
-    <span :if={Enum.member?(@block_waivered_routes, Atom.to_string(route))}>
+  <:col :let={alert} label="Route has Cancelled Trip">
+    <span :if={
+      length(@block_waivered_routes -- route_ids_from_alert(alert)) <
+        length(@block_waivered_routes)
+    }>
       ❌
     </span>
   </:col>
-  <:col :let={route} label="Alert Duration (hours)">
-    <%= @alerts_by_route[route]
-    |> Enum.max_by(&Alert.alert_duration/1)
-    |> Alert.alert_duration()
-    |> friendly_duration() %>
+
+  <:col :let={alert} label="Alert Duration (hours)">
+    <%= Alert.alert_duration(alert) |> friendly_duration() %>
   </:col>
-  <:col :let={route} label="Recommending Alert Closure">
+  <:col :let={alert} label="Recommending Alert Closure">
     <span
-      :if={Enum.member?(@routes_with_recommended_closures, route)}
+      :if={
+        length(@routes_with_recommended_closures -- route_ids_from_alert(alert)) <
+          length(@routes_with_recommended_closures)
+      }
       class="text-red-600 font-bold"
     >
       Y
     </span>
-    <span :if={!Enum.member?(@routes_with_recommended_closures, route)}>
+    <span :if={
+      length(@routes_with_recommended_closures -- route_ids_from_alert(alert)) ==
+        length(@routes_with_recommended_closures)
+    }>
       N
     </span>
   </:col>

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -16,7 +16,7 @@
   <.live_component
     module={@current_algorithm}
     id={:algorithm_controls}
-    alerts_by_route={@alerts_by_route}
+    alerts={@sorted_alerts}
     stats_by_route={@stats_by_route}
   />
 </div>
@@ -97,22 +97,12 @@
   </:col>
   <:col :let={alert} label="Recommending Alert Closure">
     <span
-      :if={
-        Enum.any?(
-          Alert.route_ids(alert),
-          &Enum.member?(@routes_with_recommended_closures, &1)
-        )
-      }
+      :if={Enum.member?(@alerts_with_recommended_closures, alert)}
       class="text-red-600 font-bold"
     >
       Y
     </span>
-    <span :if={
-      !Enum.any?(
-        Alert.route_ids(alert),
-        &Enum.member?(@routes_with_recommended_closures, &1)
-      )
-    }>
+    <span :if={!Enum.member?(@alerts_with_recommended_closures, alert)}>
       N
     </span>
   </:col>

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/adherence_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/adherence_component.ex
@@ -5,7 +5,6 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
 
   use AlertsViewerWeb, :live_component
 
-  alias Alerts.Alert
   alias AlertsViewerWeb.DateTimeHelpers
   alias Routes.RouteStats
 
@@ -36,11 +35,11 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
     alerts_by_route = Map.get(assigns, :alerts_by_route, [])
     stats_by_route = Map.get(assigns, :stats_by_route, %{})
 
-    route_id_atoms = Keyword.keys(alerts_by_route)
+    route_ids = Map.keys(alerts_by_route)
 
     routes_with_recommended_closures =
       Enum.filter(
-        route_id_atoms,
+        route_ids,
         &recommending_closure?(
           &1,
           socket.assigns.duration,
@@ -58,7 +57,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
 
     {:ok,
      assign(socket,
-       route_id_atoms: route_id_atoms,
+       route_ids: route_ids,
        stats_by_route: stats_by_route,
        alerts_by_route: alerts_by_route
      )}
@@ -128,7 +127,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
 
     routes_with_recommended_closures =
       Enum.filter(
-        socket.assigns.route_id_atoms,
+        socket.assigns.route_ids,
         &recommending_closure?(
           &1,
           duration,
@@ -148,16 +147,16 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
   end
 
   @spec recommending_closure?(
-          atom(),
+          String.t(),
           integer(),
           integer(),
           integer(),
-          keyword([Alert.t()]),
+          map(),
           RouteStats.stats_by_route()
         ) ::
           boolean()
   defp recommending_closure?(
-         route_id_atom,
+         route_id,
          duration_threshold_in_minutes,
          median_threshold_in_minutes,
          peak_threshold_in_minutes,
@@ -165,11 +164,11 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
          stats_by_route
        ) do
     current_time = DateTime.now!("America/New_York")
-    route_id = Atom.to_string(route_id_atom)
+    route_id = route_id
 
     max =
       alerts_by_route
-      |> Keyword.get(route_id_atom)
+      |> Map.get(route_id)
       |> Enum.map(& &1.created_at)
       |> Enum.max(DateTime)
 

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/adherence_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/adherence_component.ex
@@ -5,6 +5,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
 
   use AlertsViewerWeb, :live_component
 
+  alias Alerts.Alert
   alias AlertsViewerWeb.DateTimeHelpers
   alias Routes.RouteStats
 
@@ -32,34 +33,30 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
 
   @impl true
   def update(assigns, socket) do
-    alerts_by_route = Map.get(assigns, :alerts_by_route, [])
+    alerts = Map.get(assigns, :alerts, [])
     stats_by_route = Map.get(assigns, :stats_by_route, %{})
 
-    route_ids = Map.keys(alerts_by_route)
-
-    routes_with_recommended_closures =
+    alerts_with_recommended_closures =
       Enum.filter(
-        route_ids,
+        socket.assigns.alerts,
         &recommending_closure?(
           &1,
           socket.assigns.duration,
           socket.assigns.median,
           socket.assigns.peak,
-          alerts_by_route,
           stats_by_route
         )
       )
 
     send(
       self(),
-      {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+      {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
     )
 
     {:ok,
      assign(socket,
-       route_ids: route_ids,
        stats_by_route: stats_by_route,
-       alerts_by_route: alerts_by_route
+       alerts: alerts
      )}
   end
 
@@ -125,64 +122,63 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent do
     median = String.to_integer(median_str)
     peak = String.to_integer(peak_str)
 
-    routes_with_recommended_closures =
+    alerts_with_recommended_closures =
       Enum.filter(
-        socket.assigns.route_ids,
+        socket.assigns.alerts,
         &recommending_closure?(
           &1,
           duration,
           median,
           peak,
-          socket.assigns.alerts_by_route,
           socket.assigns.stats_by_route
         )
       )
 
     send(
       self(),
-      {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+      {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
     )
 
     {:noreply, assign(socket, duration: duration, median: median, peak: peak)}
   end
 
   @spec recommending_closure?(
-          String.t(),
+          Alert.t(),
           integer(),
           integer(),
           integer(),
-          map(),
           RouteStats.stats_by_route()
         ) ::
           boolean()
   defp recommending_closure?(
-         route_id,
+         alert,
          duration_threshold_in_minutes,
          median_threshold_in_minutes,
          peak_threshold_in_minutes,
-         alerts_by_route,
          stats_by_route
        ) do
     current_time = DateTime.now!("America/New_York")
-    route_id = route_id
+    route_ids = Alert.route_ids(alert)
 
-    max =
-      alerts_by_route
-      |> Map.get(route_id)
-      |> Enum.map(& &1.created_at)
-      |> Enum.max(DateTime)
-
-    duration = DateTime.diff(current_time, max, :minute)
+    duration = DateTime.diff(current_time, alert.created_at, :minute)
 
     median =
-      stats_by_route
-      |> RouteStats.median_schedule_adherence(route_id)
-      |> DateTimeHelpers.seconds_to_minutes()
+      route_ids
+      |> Enum.map(fn route_id ->
+        stats_by_route
+        |> RouteStats.median_schedule_adherence(route_id)
+        |> DateTimeHelpers.seconds_to_minutes()
+      end)
+      |> Enum.max()
 
     peak =
-      stats_by_route
-      |> RouteStats.max_schedule_adherence(route_id)
-      |> DateTimeHelpers.seconds_to_minutes()
+      route_ids
+      |> Enum.map(fn route_id ->
+        stats_by_route
+        |> RouteStats.max_schedule_adherence(route_id)
+        |> DateTimeHelpers.seconds_to_minutes()
+      end)
+      |> Enum.max()
 
     duration >= duration_threshold_in_minutes and
       (!is_nil(median) and median <= median_threshold_in_minutes) and

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/alert_duration_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/alert_duration_component.ex
@@ -37,15 +37,13 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AlertDurationComponent do
   end
 
   @spec recommending_closure?(
-          String.t(),
+          Alert.t(),
           non_neg_integer(),
-          {map(), RouteStats.stats_by_route()}
+          RouteStats.stats_by_route()
         ) ::
           boolean()
-  defp recommending_closure?(route, threshold_in_minutes, {alerts_by_route, _stats_by_route}) do
-    current_time = DateTime.now!("America/New_York")
-    max = Enum.max(Enum.map(alerts_by_route[route], & &1.created_at), DateTime)
-    duration = DateTime.diff(current_time, max, :minute)
+  defp recommending_closure?(alert, threshold_in_minutes, _stats_by_route) do
+    duration = DateTime.diff(DateTime.now!("America/New_York"), alert.created_at, :minute)
     duration >= threshold_in_minutes
   end
 end

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/alert_duration_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/alert_duration_component.ex
@@ -37,9 +37,9 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.AlertDurationComponent do
   end
 
   @spec recommending_closure?(
-          atom(),
+          String.t(),
           non_neg_integer(),
-          {Keyword.t(), RouteStats.stats_by_route()}
+          {map(), RouteStats.stats_by_route()}
         ) ::
           boolean()
   defp recommending_closure?(route, threshold_in_minutes, {alerts_by_route, _stats_by_route}) do

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/base_algorithm_components/one_slider_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/base_algorithm_components/one_slider_component.ex
@@ -32,7 +32,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.BaseAlgorithmComponents.OneSl
       def update(assigns, socket) do
         stats_by_route = Map.get(assigns, :stats_by_route, %{})
         alerts_by_route = Map.get(assigns, :alerts_by_route, [])
-        routes = Keyword.keys(alerts_by_route)
+        routes = Map.keys(alerts_by_route)
 
         routes_with_recommended_closures =
           Enum.filter(

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/base_algorithm_components/one_slider_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/base_algorithm_components/one_slider_component.ex
@@ -12,6 +12,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.BaseAlgorithmComponents.OneSl
 
       use AlertsViewerWeb, :live_component
 
+      alias Alerts.Alert
       alias Routes.{Route, RouteStats}
 
       @impl true
@@ -31,29 +32,29 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.BaseAlgorithmComponents.OneSl
       @impl true
       def update(assigns, socket) do
         stats_by_route = Map.get(assigns, :stats_by_route, %{})
-        alerts_by_route = Map.get(assigns, :alerts_by_route, [])
-        routes = Map.keys(alerts_by_route)
+        alerts = Map.get(assigns, :alerts, [])
+        routes = Map.keys(stats_by_route)
 
-        routes_with_recommended_closures =
+        alerts_with_recommended_closures =
           Enum.filter(
-            routes,
+            alerts,
             &recommending_closure?(
               &1,
               socket.assigns.min_value,
-              {alerts_by_route, stats_by_route}
+              stats_by_route
             )
           )
 
         send(
           self(),
-          {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+          {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
         )
 
         {:ok,
          assign(socket,
            routes: routes,
            stats_by_route: stats_by_route,
-           alerts_by_route: alerts_by_route
+           alerts: alerts
          )}
       end
 
@@ -61,19 +62,19 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.BaseAlgorithmComponents.OneSl
       def handle_event("update-controls", %{"min_value" => min_value_str}, socket) do
         min_value = String.to_integer(min_value_str)
 
-        routes_with_recommended_closures =
+        alerts_with_recommended_closures =
           Enum.filter(
-            socket.assigns.routes,
+            socket.assigns.alerts,
             &recommending_closure?(
               &1,
               min_value,
-              {socket.assigns.alerts_by_route, socket.assigns.stats_by_route}
+              socket.assigns.stats_by_route
             )
           )
 
         send(
           self(),
-          {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+          {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
         )
 
         {:noreply, assign(socket, min_value: min_value)}

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/headway_deviation_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/headway_deviation_component.ex
@@ -5,7 +5,6 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
 
   use AlertsViewerWeb, :live_component
 
-  alias Alerts.Alert
   alias AlertsViewerWeb.DateTimeHelpers
   alias Routes.RouteStats
 
@@ -36,11 +35,11 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
     alerts_by_route = Map.get(assigns, :alerts_by_route, [])
     stats_by_route = Map.get(assigns, :stats_by_route, %{})
 
-    route_id_atoms = Keyword.keys(alerts_by_route)
+    route_ids = Map.keys(alerts_by_route)
 
     routes_with_recommended_closures =
       Enum.filter(
-        route_id_atoms,
+        route_ids,
         &recommending_closure?(
           &1,
           socket.assigns.duration,
@@ -58,7 +57,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
 
     {:ok,
      assign(socket,
-       route_id_atoms: route_id_atoms,
+       route_ids: route_ids,
        stats_by_route: stats_by_route,
        alerts_by_route: alerts_by_route
      )}
@@ -128,7 +127,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
 
     routes_with_recommended_closures =
       Enum.filter(
-        socket.assigns.route_id_atoms,
+        socket.assigns.route_ids,
         &recommending_closure?(
           &1,
           duration,
@@ -148,16 +147,16 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
   end
 
   @spec recommending_closure?(
-          atom(),
+          String.t(),
           integer(),
           integer(),
           integer(),
-          keyword([Alert.t()]),
+          map(),
           RouteStats.stats_by_route()
         ) ::
           boolean()
   defp recommending_closure?(
-         route_id_atom,
+         route_id,
          duration_threshold_in_minutes,
          median_threshold_in_minutes,
          peak_threshold_in_minutes,
@@ -165,11 +164,11 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
          stats_by_route
        ) do
     current_time = DateTime.now!("America/New_York")
-    route_id = Atom.to_string(route_id_atom)
+    route_id = route_id
 
     max =
       alerts_by_route
-      |> Keyword.get(route_id_atom)
+      |> Map.get(route_id)
       |> Enum.map(& &1.created_at)
       |> Enum.max(DateTime)
 

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/headway_deviation_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/headway_deviation_component.ex
@@ -5,6 +5,7 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
 
   use AlertsViewerWeb, :live_component
 
+  alias Alerts.Alert
   alias AlertsViewerWeb.DateTimeHelpers
   alias Routes.RouteStats
 
@@ -32,34 +33,30 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
 
   @impl true
   def update(assigns, socket) do
-    alerts_by_route = Map.get(assigns, :alerts_by_route, [])
+    alerts = Map.get(assigns, :alerts, [])
     stats_by_route = Map.get(assigns, :stats_by_route, %{})
 
-    route_ids = Map.keys(alerts_by_route)
-
-    routes_with_recommended_closures =
+    alerts_with_recommended_closures =
       Enum.filter(
-        route_ids,
+        alerts,
         &recommending_closure?(
           &1,
           socket.assigns.duration,
           socket.assigns.median,
           socket.assigns.peak,
-          alerts_by_route,
           stats_by_route
         )
       )
 
     send(
       self(),
-      {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+      {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
     )
 
     {:ok,
      assign(socket,
-       route_ids: route_ids,
        stats_by_route: stats_by_route,
-       alerts_by_route: alerts_by_route
+       alerts: alerts
      )}
   end
 
@@ -125,64 +122,63 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent do
     median = String.to_integer(median_str)
     peak = String.to_integer(peak_str)
 
-    routes_with_recommended_closures =
+    alerts_with_recommended_closures =
       Enum.filter(
-        socket.assigns.route_ids,
+        socket.assigns.alerts,
         &recommending_closure?(
           &1,
           duration,
           median,
           peak,
-          socket.assigns.alerts_by_route,
           socket.assigns.stats_by_route
         )
       )
 
     send(
       self(),
-      {:updated_routes_with_recommended_closures, routes_with_recommended_closures}
+      {:updated_alerts_with_recommended_closures, alerts_with_recommended_closures}
     )
 
     {:noreply, assign(socket, duration: duration, median: median, peak: peak)}
   end
 
   @spec recommending_closure?(
-          String.t(),
+          Alert.t(),
           integer(),
           integer(),
           integer(),
-          map(),
           RouteStats.stats_by_route()
         ) ::
           boolean()
   defp recommending_closure?(
-         route_id,
+         alert,
          duration_threshold_in_minutes,
          median_threshold_in_minutes,
          peak_threshold_in_minutes,
-         alerts_by_route,
          stats_by_route
        ) do
     current_time = DateTime.now!("America/New_York")
-    route_id = route_id
+    route_ids = Alert.route_ids(alert)
 
-    max =
-      alerts_by_route
-      |> Map.get(route_id)
-      |> Enum.map(& &1.created_at)
-      |> Enum.max(DateTime)
-
-    duration = DateTime.diff(current_time, max, :minute)
+    duration = DateTime.diff(current_time, alert.created_at, :minute)
 
     median =
-      stats_by_route
-      |> RouteStats.median_headway_deviation(route_id)
-      |> DateTimeHelpers.seconds_to_minutes()
+      route_ids
+      |> Enum.map(fn route_id ->
+        stats_by_route
+        |> RouteStats.median_headway_deviation(route_id)
+        |> DateTimeHelpers.seconds_to_minutes()
+      end)
+      |> Enum.max()
 
     peak =
-      stats_by_route
-      |> RouteStats.max_headway_deviation(route_id)
-      |> DateTimeHelpers.seconds_to_minutes()
+      route_ids
+      |> Enum.map(fn route_id ->
+        stats_by_route
+        |> RouteStats.max_headway_deviation(route_id)
+        |> DateTimeHelpers.seconds_to_minutes()
+      end)
+      |> Enum.max()
 
     duration >= duration_threshold_in_minutes and
       (!is_nil(median) and median <= median_threshold_in_minutes) and

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_adherence_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_adherence_component.ex
@@ -37,13 +37,21 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.MedianAdherenceComponent do
   end
 
   @spec recommending_closure?(
-          String.t() | Route.t(),
+          Alert.t(),
           non_neg_integer(),
-          {map(), RouteStats.stats_by_route()}
+          RouteStats.stats_by_route()
         ) ::
           boolean()
-  defp recommending_closure?(route, threshold_in_minutes, {_alerts_by_route, stats_by_route}) do
-    median = RouteStats.median_schedule_adherence(stats_by_route, route)
+  defp recommending_closure?(alert, threshold_in_minutes, stats_by_route) do
+    route_ids = Alert.route_ids(alert)
+
+    median =
+      route_ids
+      |> Enum.map(fn route_id ->
+        RouteStats.median_schedule_adherence(stats_by_route, route_id)
+      end)
+      |> Enum.max()
+
     !is_nil(median) and median >= threshold_in_minutes * 60
   end
 end

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_adherence_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_adherence_component.ex
@@ -37,13 +37,13 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.MedianAdherenceComponent do
   end
 
   @spec recommending_closure?(
-          atom(),
+          String.t() | Route.t(),
           non_neg_integer(),
-          {Keyword.t(), RouteStats.stats_by_route()}
+          {map(), RouteStats.stats_by_route()}
         ) ::
           boolean()
   defp recommending_closure?(route, threshold_in_minutes, {_alerts_by_route, stats_by_route}) do
-    median = RouteStats.median_schedule_adherence(stats_by_route, Atom.to_string(route))
+    median = RouteStats.median_schedule_adherence(stats_by_route, route)
     !is_nil(median) and median >= threshold_in_minutes * 60
   end
 end

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_headway_deviation_diff_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_headway_deviation_diff_component.ex
@@ -37,17 +37,23 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.MedianHeadwayDeviationDiffCom
   end
 
   @spec recommending_closure?(
-          String.t(),
+          Alert.t(),
           non_neg_integer(),
-          {map(), RouteStats.stats_by_route()}
+          RouteStats.stats_by_route()
         ) ::
           boolean()
-  defp recommending_closure?(route, threshold_in_minutes, {_alerts_by_route, stats_by_route}) do
+  defp recommending_closure?(alert, threshold_in_minutes, stats_by_route) do
+    route_ids = Alert.route_ids(alert)
+
     median =
-      RouteStats.median_headway_deviation(
-        stats_by_route,
-        route
-      )
+      route_ids
+      |> Enum.map(fn route_id ->
+        RouteStats.median_headway_deviation(
+          stats_by_route,
+          route_id
+        )
+      end)
+      |> Enum.max()
 
     !is_nil(median) and median >= threshold_in_minutes * 60
   end

--- a/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_headway_deviation_diff_component.ex
+++ b/lib/alerts_viewer_web/live/stop_recommendation_algorithm/median_headway_deviation_diff_component.ex
@@ -37,16 +37,16 @@ defmodule AlertsViewer.StopRecommendationAlgorithm.MedianHeadwayDeviationDiffCom
   end
 
   @spec recommending_closure?(
-          atom(),
+          String.t(),
           non_neg_integer(),
-          {Keyword.t(), RouteStats.stats_by_route()}
+          {map(), RouteStats.stats_by_route()}
         ) ::
           boolean()
   defp recommending_closure?(route, threshold_in_minutes, {_alerts_by_route, stats_by_route}) do
     median =
       RouteStats.median_headway_deviation(
         stats_by_route,
-        Atom.to_string(route)
+        route
       )
 
     !is_nil(median) and median >= threshold_in_minutes * 60

--- a/lib/routes.ex
+++ b/lib/routes.ex
@@ -21,9 +21,9 @@ defmodule Routes do
 
   @spec get_by_id([Route.t()], String.t()) :: Route.t() | nil
   def get_by_id(routes, route_id) do
-    case filtered_routes = Enum.filter(routes, &(&1.id == route_id)) do
+    case Enum.filter(routes, &(&1.id == route_id)) do
       [] -> nil
-      [_ | _] -> hd(filtered_routes)
+      [route | _] -> route
     end
   end
 

--- a/lib/routes.ex
+++ b/lib/routes.ex
@@ -19,9 +19,12 @@ defmodule Routes do
     end
   end
 
-  @spec get_by_id([Route.t()], String.t()) :: Route.t()
+  @spec get_by_id([Route.t()], String.t()) :: Route.t() | nil
   def get_by_id(routes, route_id) do
-    routes |> Enum.filter(&(&1.id == route_id)) |> hd()
+    case filtered_routes = Enum.filter(routes, &(&1.id == route_id)) do
+      [] -> nil
+      [_ | _] -> hd(filtered_routes)
+    end
   end
 
   @spec get_all_bus_routes(keyword()) :: {:ok, [Route.t()]} | {:error, any}


### PR DESCRIPTION
Rows are now by alert, not route.

Routes without names are filtered out from display. Stats columns with multiple routes display comma-separated, route closures and dropped trips will show if any route on the alert qualifies. Aside from combined routes, alerts with multiple routes appear to be an edge case.

I also had to do a bit of refactoring since we don't need to arrange the page around a keyword list anymore.

Asana task: https://app.asana.com/0/1167196461144361/1205250462129249/f