### PR TITLE
Use heroicons library functions

### DIFF
--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -80,7 +80,7 @@ defmodule AlertsViewerWeb.CoreComponents do
                   class="-m-3 flex-none p-3 opacity-20 hover:opacity-40"
                   aria-label={gettext("close")}
                 >
-                  <.icon name="hero-x-mark-solid" class="w-5 h-5" />
+                  <Heroicons.x_mark class="w-5 h-5" />
                 </button>
               </div>
               <div id={"#{@id}-content"}>
@@ -158,8 +158,8 @@ defmodule AlertsViewerWeb.CoreComponents do
       {@rest}
     >
       <p :if={@title} class="flex items-center gap-1.5 text-[0.8125rem] font-semibold leading-6">
-        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="w-4 h-4" />
-        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="w-4 h-4" />
+        <Heroicons.information_circle :if={@kind == :info} mini class="w-4 h-4" />
+        <Heroicons.exclamation_circle :if={@kind == :error} mini class="w-4 h-4" />
         <%= @title %>
       </p>
       <p class="mt-2 text-[0.8125rem] leading-5"><%= msg %></p>
@@ -169,7 +169,7 @@ defmodule AlertsViewerWeb.CoreComponents do
         class="group absolute top-2 right-1 p-2"
         aria-label={gettext("close")}
       >
-        <.icon name="hero-x-mark-solid" class="w-5 h-5 opacity-40 group-hover:opacity-70" />
+        <Heroicons.x_mark class="w-5 h-5 opacity-40 group-hover:opacity-70" />
       </button>
     </div>
     """
@@ -197,7 +197,7 @@ defmodule AlertsViewerWeb.CoreComponents do
       phx-disconnected={show("#disconnected")}
       phx-connected={hide("#disconnected")}
     >
-      Attempting to reconnect <.icon name="hero-arrow-path" class="ml-1 w-3 h-3 animate-spin" />
+      Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 animate-spin" />
     </.flash>
     """
   end
@@ -484,7 +484,7 @@ defmodule AlertsViewerWeb.CoreComponents do
   def error(assigns) do
     ~H"""
     <p class="phx-no-feedback:hidden mt-3 flex gap-3 text-sm leading-6 text-rose-600">
-      <.icon name="hero-exclamation-circle-mini" class="mt-0.5 w-5 h-5 flex-none" />
+      <Heroicons.exclamation_circle mini class="mt-0.5 w-5 h-5 flex-none" />
       <%= render_slot(@inner_block) %>
     </p>
     """
@@ -691,39 +691,10 @@ defmodule AlertsViewerWeb.CoreComponents do
         navigate={@navigate}
         class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
       >
-        <.icon name="hero-arrow-left-solid" class="w-3 h-3" />
+        <Heroicons.arrow_left class="w-3 h-3" />
         <%= render_slot(@inner_block) %>
       </.link>
     </div>
-    """
-  end
-
-  @doc """
-  Renders a [Hero Icon](https://heroicons.com).
-
-  Hero icons come in three styles – outline, solid, and mini.
-  By default, the outline style is used, but solid an mini may
-  be applied by using the `-solid` and `-mini` suffix.
-
-  You can customize the size and colors of the icons by setting
-  width, height, and background color classes.
-
-  Icons are extracted from your `priv/hero_icons` directory and bundled
-  within your compiled app.css by the plugin in your `assets/tailwind.config.js`.
-
-  ## Examples
-
-      <.icon name="hero-cake" />
-      <.icon name="hero-cake-solid" />
-      <.icon name="hero-cake-mini" />
-      <.icon name="hero-bolt" class="bg-blue-500 w-10 h-10" />
-  """
-  attr(:name, :string, required: true)
-  attr(:class, :string, default: nil)
-
-  def icon(%{name: "hero-" <> _} = assigns) do
-    ~H"""
-    <span class={[@name, @class]} />
     """
   end
 


### PR DESCRIPTION
I noticed that we were using heroicons but none of them were showing up. Upon further investigations, the function we were using to show them requires a plugin to be added to the tailwind config file, and the individual svgs to be added to the asset folder (the plugin not being defined was why these were just kind of failing silently). Additionally we were importing the elixir [Heroicons library](https://hexdocs.pm/heroicons/Heroicons.html) but not using it. I switched all instances of icons over to using Heroicons library functions and deleted the old import code.

We were really only using them in a few places, but now we can add heroicons icons to our heart's content.

No ticket, this is more of a bugfix

Before:

![Screenshot 2023-08-15 at 10 22 46 AM](https://github.com/mbta/alerts_viewer/assets/17047573/48f4e16c-b0d3-4ce0-ac4e-fbd43311ef1e)


After:


![Screenshot 2023-08-15 at 10 23 01 AM](https://github.com/mbta/alerts_viewer/assets/17047573/84592e73-1015-42ef-aff6-315e1eb59ce3)

