### PR TITLE
Various Stylings

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -32,12 +32,12 @@ window.addEventListener("phx:page-loading-stop", info => topbar.hide())
 
 // Copy to the clipboard
 window.addEventListener("alerts_viewer:clipcopy", (event) => {
-    if ("clipboard" in navigator) {
-        const text = event.target.textContent.trim();
-        navigator.clipboard.writeText(text);
-    } else {
-        alert("Sorry, your browser does not support clipboard copy.");
-    }
+  if ("clipboard" in navigator) {
+    const text = event.target.textContent.trim();
+    navigator.clipboard.writeText(text);
+  } else {
+    alert("Sorry, your browser does not support clipboard copy.");
+  }
 });
 
 // connect if there are any LiveViews on the page

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,17 +18,27 @@
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
-import {Socket} from "phoenix"
-import {LiveSocket} from "phoenix_live_view"
+import { Socket } from "phoenix"
+import { LiveSocket } from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken } })
 
 // Show progress bar on live navigation and form submits
-topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", info => topbar.delayedShow(200))
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
+
+// Copy to the clipboard
+window.addEventListener("alerts_viewer:clipcopy", (event) => {
+    if ("clipboard" in navigator) {
+        const text = event.target.textContent.trim();
+        navigator.clipboard.writeText(text);
+    } else {
+        alert("Sorry, your browser does not support clipboard copy.");
+    }
+});
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -517,11 +517,13 @@ defmodule AlertsViewerWeb.CoreComponents do
 
   @doc ~S"""
   Renders a table with generic styling.
+  You can style rows by giving the row map a :row_class key with the classes as the value
+  Eg: rows |> Enum.map(& Map.put(&1, :row_class, "text-fuchsia-500 bg-orange-300"))
 
   ## Examples
 
       <.table id="users" rows={@users}>
-        <:col :let={user} label="id"><%= user.id %></:col>
+        <:col :let={user} label="id" title="hello world"><%= user.id %></:col>
         <:col :let={user} label="username"><%= user.username %></:col>
       </.table>
   """
@@ -538,6 +540,7 @@ defmodule AlertsViewerWeb.CoreComponents do
 
   slot :col, required: true do
     attr(:label, :string)
+    attr(:title, :string, required: false)
   end
 
   slot(:action, doc: "the slot for showing user actions in the last table column")
@@ -553,7 +556,9 @@ defmodule AlertsViewerWeb.CoreComponents do
       <table class="mt-11 w-[40rem] sm:w-full">
         <thead class={"text-left text-[0.8125rem] leading-6 text-zinc-500 z-10 #{if(@sticky, do: ~s(sticky top-0  bg-white), else: ~s())}"}>
           <tr>
-            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal"><%= col[:label] %></th>
+            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal" title={Map.get(col, :title, "")}>
+              <%= col[:label] %>
+            </th>
             <th class="relative p-0 pb-4"><span class="sr-only"><%= gettext("Actions") %></span></th>
           </tr>
         </thead>
@@ -570,7 +575,11 @@ defmodule AlertsViewerWeb.CoreComponents do
             >
               <div class="block py-4 pr-6">
                 <span class="absolute -inset-y-px right-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
-                <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
+                <span class={[
+                  "relative",
+                  i == 0 && "font-semibold text-zinc-900",
+                  Map.get(row, :row_class, "")
+                ]}>
                   <%= render_slot(col, @row_item.(row)) %>
                 </span>
               </div>

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.ex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.ex
@@ -27,13 +27,15 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
 
     block_waivered_routes = if(connected?(socket), do: TripUpdatesPubSub.subscribe(), else: [])
 
+    recommended_closures = recommended_closures(sorted_alerts, stats_by_route)
+
     socket =
       assign(socket,
         stats_by_route: stats_by_route,
         bus_routes: bus_routes,
         block_waivered_routes: block_waivered_routes,
         sorted_alerts: sorted_alerts,
-        alerts_with_recommended_closures: []
+        alerts_with_recommended_closures: recommended_closures
       )
 
     {:ok, socket}
@@ -135,6 +137,7 @@ defmodule AlertsViewerWeb.AlertsToCloseLive do
         |> RouteStats.max_headway_deviation(route_id)
         |> DateTimeHelpers.seconds_to_minutes()
       end)
+      |> Enum.reject(&is_nil/1)
       |> Enum.max()
 
     duration >= duration_threshold_in_minutes and

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -2,14 +2,36 @@
   Canidates to Close
 </.header>
 
-<.table id="bus_alerts" sticky={true} rows={@sorted_alerts}>
+<.table
+  id="bus_alerts"
+  sticky={true}
+  rows={
+    @sorted_alerts
+    |> Enum.map(fn alert ->
+      case Enum.member?(@alerts_with_recommended_closures, alert) do
+        true -> alert
+        false -> Map.put(alert, :row_class, " text-zinc-300")
+      end
+    end)
+  }
+>
   <:col :let={alert} label="Alert Id (sorted by duration)">
-    <%= alert.id %>
+    <button
+      phx-click={JS.dispatch("alerts_viewer:clipcopy", to: "#alert#{alert.id}")}
+      title="Copy ID to Clipboard"
+    >
+      <div class="flex">
+        <span id={"alert" <> alert.id} class="mr-2">
+          <%= alert.id %>
+        </span>
+        <Heroicons.document_duplicate class="w-3 h-3 text-emerald-400" />
+      </div>
+    </button>
   </:col>
   <:col :let={alert} label="Route Names">
     <.informed_entity_icons entities={route_names_from_alert(alert, @bus_routes)} />
   </:col>
-  <:col :let={alert} label="Median Adherence (minutes)">
+  <:col :let={alert} label=" Average Adherence (minutes)">
     <%= alert
     |> Alert.route_ids()
     |> Enum.map(fn route_id ->
@@ -20,40 +42,11 @@
     |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
-  <:col :let={alert} label="Peak Adherence (minutes)">
-    <%= alert
-    |> Alert.route_ids()
-    |> Enum.map(fn route_id ->
-      @stats_by_route
-      |> RouteStats.max_schedule_adherence(route_id)
-      |> seconds_to_minutes()
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join(",") %>
-  </:col>
-  <:col :let={alert} label="Median Instantaneous Headway (minutes)">
-    <%= alert
-    |> Alert.route_ids()
-    |> Enum.map(fn route_id ->
-      @stats_by_route
-      |> RouteStats.median_instantaneous_headway(route_id)
-      |> seconds_to_minutes()
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join(",") %>
-  </:col>
-  <:col :let={alert} label="Median Headway Deviation (minutes)">
-    <%= alert
-    |> Alert.route_ids()
-    |> Enum.map(fn route_id ->
-      @stats_by_route
-      |> RouteStats.median_headway_deviation(route_id)
-      |> seconds_to_minutes()
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join(",") %>
-  </:col>
-  <:col :let={alert} label="Peak Headway Deviation (minutes)">
+  <:col
+    :let={alert}
+    label="Peak Headway Deviation (minutes)⇪"
+    title="The difference between a vehicle's actual headway and its scheduled headway."
+  >
     <%= alert
     |> Alert.route_ids()
     |> Enum.map(fn route_id ->
@@ -64,19 +57,16 @@
     |> Enum.reject(&is_nil/1)
     |> Enum.join(",") %>
   </:col>
-  <:col :let={alert} label="Route has Cancelled Trip">
-    <span :if={
-      length(@block_waivered_routes -- Alert.route_ids(alert)) <
-        length(@block_waivered_routes)
-    }>
-      ❌
+  <:col :let={alert} label="Route has Dropped Trip">
+    <span :if={Alert.route_ids(alert) |> Enum.any?(&Enum.member?(@block_waivered_routes, &1))}>
+      <Heroicons.minus_circle class="text-red-400 w-7 h-7" title="Dropped Trip" />
     </span>
   </:col>
 
-  <:col :let={alert} label="Alert Duration (hours)">
+  <:col :let={alert} label="Alert Open For">
     <%= Alert.alert_duration(alert) |> friendly_duration() %>
   </:col>
-  <:col :let={alert} label="Recommending Alert Closure">
+  <:col :let={alert} label="Recommending Closure">
     <span
       :if={Enum.member?(@alerts_with_recommended_closures, alert)}
       class="text-red-600 font-bold"

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -31,7 +31,7 @@
   <:col :let={alert} label="Route Names">
     <.informed_entity_icons entities={route_names_from_alert(alert, @bus_routes)} />
   </:col>
-  <:col :let={alert} label=" Average Adherence (minutes)">
+  <:col :let={alert} label="Average Adherence (minutes)">
     <%= alert
     |> Alert.route_ids()
     |> Enum.map(fn route_id ->

--- a/lib/alerts_viewer_web/live/open_delay_alerts_live.html.heex
+++ b/lib/alerts_viewer_web/live/open_delay_alerts_live.html.heex
@@ -84,10 +84,7 @@
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Route has Cancelled Trip">
-    <span :if={
-      length(@block_waivered_routes -- Alert.route_ids(alert)) <
-        length(@block_waivered_routes)
-    }>
+    <span :if={Alert.route_ids(alert) |> Enum.any?(&Enum.member?(@block_waivered_routes, &1))}>
       ❌
     </span>
   </:col>


### PR DESCRIPTION
Changes to "Alerts to Close" page:

- number of columns reduced
- title 'tooltip' added to Peak Deviation column header
- rows without recommended alerts are muted
- wording change on dropped trip
- dropped trip icon changed to circle with minus sign
- alert ids can be copied to clipboard
- Adherence called median instead of average

Also contains a few small fixes I missed in the last PR.

Asana ticket: https://app.asana.com/0/1167196461144361/1205250462129251/f
and also https://app.asana.com/0/1167196461144361/1205250462129252/f