### PR TITLE
Stop time update arrivals are in unix time

### DIFF
--- a/lib/trip_updates/trip_updates_pub_sub.ex
+++ b/lib/trip_updates/trip_updates_pub_sub.ex
@@ -120,6 +120,7 @@ defmodule TripUpdates.TripUpdatesPubSub do
     trip_update.stop_time_update
     |> Enum.map(& &1.arrival_time)
     |> Enum.reject(&is_nil(&1))
+    |> Enum.map(&DateTime.from_unix!(&1))
     |> Enum.max(DateTime, fn -> nil end)
   end
 end

--- a/test/trip_updates/trip_updates_pub_sub_test.exs
+++ b/test/trip_updates/trip_updates_pub_sub_test.exs
@@ -3,7 +3,8 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
   alias TripUpdates.{StopTimeUpdate, TripUpdate, TripUpdatesPubSub}
 
   @stop_time_update_with_waiver %StopTimeUpdate{
-    arrival_time: DateTime.now!("America/New_York") |> DateTime.add(2, :hour),
+    arrival_time:
+      DateTime.now!("America/New_York") |> DateTime.add(2, :hour) |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: 12,
     cause_description: nil,
@@ -16,7 +17,7 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
   }
 
   @stop_time_update_without_waiver %StopTimeUpdate{
-    arrival_time: DateTime.now!("America/New_York"),
+    arrival_time: DateTime.now!("America/New_York") |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: nil,
     cause_description: nil,
@@ -130,14 +131,14 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
         Map.put(
           @stop_time_update_with_waiver,
           :arrival_time,
-          DateTime.add(current_time, 1, :hour)
+          DateTime.add(current_time, 1, :hour) |> DateTime.to_unix()
         )
 
       stale_stoptime =
         Map.put(
           @stop_time_update_with_waiver,
           :arrival_time,
-          DateTime.add(current_time, -1, :hour)
+          DateTime.add(current_time, -1, :hour) |> DateTime.to_unix()
         )
 
       stale_tripupdate = %TripUpdate{
@@ -162,6 +163,7 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
           @stop_time_update_with_waiver,
           :arrival_time,
           DateTime.add(current_time, -2, :hour)
+          |> DateTime.to_unix()
         )
 
       staler_stoptime =
@@ -169,6 +171,7 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
           @stop_time_update_with_waiver,
           :arrival_time,
           DateTime.add(current_time, -3, :hour)
+          |> DateTime.to_unix()
         )
 
       stale_tripupdate = %TripUpdate{

--- a/test/trip_updates/trip_updates_test.exs
+++ b/test/trip_updates/trip_updates_test.exs
@@ -9,7 +9,8 @@ defmodule TripUpdates.TripUpdatesTest do
   }
 
   @stop_time_update_with_waiver %StopTimeUpdate{
-    arrival_time: DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York"),
+    arrival_time:
+      DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York") |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: 12,
     cause_description: nil,
@@ -22,7 +23,8 @@ defmodule TripUpdates.TripUpdatesTest do
   }
 
   @stop_time_update_without_waiver %StopTimeUpdate{
-    arrival_time: DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York"),
+    arrival_time:
+      DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York") |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: nil,
     cause_description: nil,


### PR DESCRIPTION
It was handling StopTimeUpdate arrivals as if they were datetimes, but they're unix timestamps.

No card, bugfix