### PR TITLE
Use schedule relationship to detect dropped trip

### DIFF
--- a/lib/alerts_viewer_web/components/core_components.ex
+++ b/lib/alerts_viewer_web/components/core_components.ex
@@ -553,10 +553,14 @@ defmodule AlertsViewerWeb.CoreComponents do
 
     ~H"""
     <div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
-      <table class="mt-11 w-[40rem] sm:w-full">
+      <table class="mt-11 w-[40rem] sm:w-full text-center">
         <thead class={"text-left text-[0.8125rem] leading-6 text-zinc-500 z-10 #{if(@sticky, do: ~s(sticky top-0  bg-white), else: ~s())}"}>
           <tr>
-            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal" title={Map.get(col, :title, "")}>
+            <th
+              :for={col <- @col}
+              class="p-0 pb-4 pr-6 font-normal text-center"
+              title={Map.get(col, :title, "")}
+            >
               <%= col[:label] %>
             </th>
             <th class="relative p-0 pb-4"><span class="sr-only"><%= gettext("Actions") %></span></th>
@@ -609,7 +613,7 @@ defmodule AlertsViewerWeb.CoreComponents do
 
   def informed_entity_icons(assigns) do
     ~H"""
-    <ul class="flex flex-wrap gap-1">
+    <ul class="flex flex-wrap gap-1 justify-center">
       <li :for={entity <- @entities}>
         <.mode_icon type={entity} />
       </li>

--- a/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
+++ b/lib/alerts_viewer_web/live/alerts_to_close_live.html.heex
@@ -58,8 +58,14 @@
     |> Enum.join(",") %>
   </:col>
   <:col :let={alert} label="Route has Dropped Trip">
-    <span :if={Alert.route_ids(alert) |> Enum.any?(&Enum.member?(@block_waivered_routes, &1))}>
-      <Heroicons.minus_circle class="text-red-400 w-7 h-7" title="Dropped Trip" />
+    <span
+      :if={Alert.route_ids(alert) |> Enum.any?(&Enum.member?(@block_waivered_routes, &1))}
+      class="flex justify-center"
+    >
+      <Heroicons.minus_circle
+        class={"text-red-#{if Enum.member?(@alerts_with_recommended_closures, alert), do: "400", else: "200"} w-7 h-7"}
+        title="Dropped Trip"
+      />
     </span>
   </:col>
 

--- a/test/trip_updates/trip_updates_pub_sub_test.exs
+++ b/test/trip_updates/trip_updates_pub_sub_test.exs
@@ -1,28 +1,14 @@
 defmodule TripUpdates.TripUpdatesPubSubTest do
   use ExUnit.Case
-  alias TripUpdates.{StopTimeUpdate, TripUpdate, TripUpdatesPubSub}
+  alias TripUpdates.{StopTimeUpdate, Trip, TripUpdate, TripUpdatesPubSub}
 
-  @stop_time_update_with_waiver %StopTimeUpdate{
+  @stop_time_update %StopTimeUpdate{
     arrival_time:
       DateTime.now!("America/New_York") |> DateTime.add(2, :hour) |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: 12,
     cause_description: nil,
     remark: nil,
-    schedule_relationship: :SKIPPED,
-    status: nil,
-    stop_id: "s1",
-    stop_sequence: nil,
-    uncertainty: nil
-  }
-
-  @stop_time_update_without_waiver %StopTimeUpdate{
-    arrival_time: DateTime.now!("America/New_York") |> DateTime.to_unix(),
-    departure_time: nil,
-    cause_id: nil,
-    cause_description: nil,
-    remark: nil,
-    schedule_relationship: :SKIPPED,
     status: nil,
     stop_id: "s1",
     stop_sequence: nil,
@@ -34,24 +20,26 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
       start_date: nil,
       start_time: nil,
       stop_time_update: [
-        @stop_time_update_with_waiver,
-        @stop_time_update_with_waiver
+        @stop_time_update,
+        @stop_time_update
       ],
-      trip: %{
+      trip: %Trip{
         trip_id: "t1",
-        route_id: "2"
+        route_id: "2",
+        schedule_relationship: :CANCELED
       }
     },
     %TripUpdate{
       start_date: nil,
       start_time: nil,
       stop_time_update: [
-        @stop_time_update_with_waiver,
-        @stop_time_update_without_waiver
+        @stop_time_update,
+        @stop_time_update
       ],
-      trip: %{
+      trip: %Trip{
         trip_id: "t1",
-        route_id: "3"
+        route_id: "3",
+        schedule_relationship: :SKIPPED
       }
     }
   ]
@@ -120,94 +108,6 @@ defmodule TripUpdates.TripUpdatesPubSubTest do
       TripUpdatesPubSub.update_block_waivered_routes(@all_updates, pid)
 
       assert_receive {:block_waivered_routes, @block_waivered_routes}
-    end
-  end
-
-  describe "is_it_fresh" do
-    test "returns true if most recent stop time is in the future" do
-      current_time = DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York")
-
-      fresh_stoptime =
-        Map.put(
-          @stop_time_update_with_waiver,
-          :arrival_time,
-          DateTime.add(current_time, 1, :hour) |> DateTime.to_unix()
-        )
-
-      stale_stoptime =
-        Map.put(
-          @stop_time_update_with_waiver,
-          :arrival_time,
-          DateTime.add(current_time, -1, :hour) |> DateTime.to_unix()
-        )
-
-      stale_tripupdate = %TripUpdate{
-        stop_time_update: [
-          stale_stoptime,
-          fresh_stoptime
-        ],
-        trip: %{
-          trip_id: "t1",
-          route_id: "2"
-        }
-      }
-
-      assert TripUpdatesPubSub.is_it_fresh?(stale_tripupdate, current_time) == true
-    end
-
-    test "returns false if most recent stop time in the past" do
-      current_time = DateTime.new!(~D[2023-07-21], ~T[16:26:08.003], "America/New_York")
-
-      stale_stoptime =
-        Map.put(
-          @stop_time_update_with_waiver,
-          :arrival_time,
-          DateTime.add(current_time, -2, :hour)
-          |> DateTime.to_unix()
-        )
-
-      staler_stoptime =
-        Map.put(
-          @stop_time_update_with_waiver,
-          :arrival_time,
-          DateTime.add(current_time, -3, :hour)
-          |> DateTime.to_unix()
-        )
-
-      stale_tripupdate = %TripUpdate{
-        stop_time_update: [
-          stale_stoptime,
-          staler_stoptime
-        ],
-        trip: %{
-          trip_id: "t1",
-          route_id: "2"
-        }
-      }
-
-      assert TripUpdatesPubSub.is_it_fresh?(stale_tripupdate, current_time) == false
-    end
-
-    test "returns false if all stop time update arrival times are nil" do
-      bad_stoptime =
-        Map.put(
-          @stop_time_update_with_waiver,
-          :arrival_time,
-          nil
-        )
-
-      bad_tripupdate = %TripUpdate{
-        stop_time_update: [
-          bad_stoptime,
-          bad_stoptime
-        ],
-        trip: %{
-          trip_id: "t1",
-          route_id: "2"
-        }
-      }
-
-      assert TripUpdatesPubSub.is_it_fresh?(bad_tripupdate) == false
     end
   end
 end

--- a/test/trip_updates/trip_updates_test.exs
+++ b/test/trip_updates/trip_updates_test.exs
@@ -1,35 +1,27 @@
 defmodule TripUpdates.TripUpdatesTest do
   use ExUnit.Case
 
-  alias TripUpdates.{StopTimeUpdate, TripUpdate, TripUpdates}
+  alias TripUpdates.{StopTimeUpdate, Trip, TripUpdate, TripUpdates}
 
-  @trip %{
+  @trip_with_waiver %Trip{
     trip_id: "t1",
-    route_id: "2"
+    route_id: "2",
+    schedule_relationship: :CANCELED
   }
 
-  @stop_time_update_with_waiver %StopTimeUpdate{
+  @trip_without_waiver %Trip{
+    trip_id: "t1",
+    route_id: "3",
+    schedule_relationship: :SKIPPED
+  }
+
+  @stop_time_update %StopTimeUpdate{
     arrival_time:
       DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York") |> DateTime.to_unix(),
     departure_time: nil,
     cause_id: 12,
     cause_description: nil,
     remark: nil,
-    schedule_relationship: :SKIPPED,
-    status: nil,
-    stop_id: "s1",
-    stop_sequence: nil,
-    uncertainty: nil
-  }
-
-  @stop_time_update_without_waiver %StopTimeUpdate{
-    arrival_time:
-      DateTime.new!(~D[2023-07-21], ~T[09:26:08.003], "America/New_York") |> DateTime.to_unix(),
-    departure_time: nil,
-    cause_id: nil,
-    cause_description: nil,
-    remark: nil,
-    schedule_relationship: :SKIPPED,
     status: nil,
     stop_id: "s1",
     stop_sequence: nil,
@@ -41,19 +33,19 @@ defmodule TripUpdates.TripUpdatesTest do
       start_date: nil,
       start_time: nil,
       stop_time_update: [
-        @stop_time_update_with_waiver,
-        @stop_time_update_with_waiver
+        @stop_time_update,
+        @stop_time_update
       ],
-      trip: @trip
+      trip: @trip_with_waiver
     },
     %TripUpdate{
       start_date: nil,
       start_time: nil,
       stop_time_update: [
-        @stop_time_update_with_waiver,
-        @stop_time_update_without_waiver
+        @stop_time_update,
+        @stop_time_update
       ],
-      trip: @trip
+      trip: @trip_without_waiver
     }
   ]
 


### PR DESCRIPTION
Looks at the schedule_relationship in the trip instead of stop update reason to detect dropped trips.

Also added some centering to the table, and the dropped trip icon is now dim if the row isn't a suggested closure.

Asana ticket: https://app.asana.com/0/1167196461144361/1205354484020913/f