### PR TITLE
add laboratory library for flags, get it to work in liveview

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -86,16 +86,16 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# Import environment specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
-import_config "#{config_env()}.exs"
-
 config :laboratory,
   features: [
-    {:internal_pages_flag, "Internal Pages", "Makes links to internal-only pages visible"}
+    {:show_internal_pages_flag, "Internal Pages", "Makes links to internal-only pages visible"}
   ],
   cookie: [
     # one month,
     max_age: 3600 * 24 * 30,
     http_only: true
   ]
+
+# Import environment specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -89,3 +89,13 @@ config :phoenix, :json_library, Jason
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
+
+config :laboratory,
+  features: [
+    {:internal_pages_flag, "Internal Pages", "Makes links to internal-only pages visible"}
+  ],
+  cookie: [
+    # one month,
+    max_age: 3600 * 24 * 30,
+    http_only: true
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,3 +26,14 @@ config :exvcr,
   vcr_cassette_library_dir: "test/support/fixtures/vcr_cassettes",
   custom_cassette_library_dir: "test/support/fixtures/custom_cassettes",
   filter_request_headers: ["x-api-key"]
+
+config :laboratory,
+  features: [
+    {:test_flag, "Cool Bean", "cool bean for test"},
+    {:show_internal_pages_flag, "Internal Pages", "Makes links to internal-only pages visible"}
+  ],
+  cookie: [
+    # one month,
+    max_age: 3600 * 24 * 30,
+    http_only: true
+  ]

--- a/lib/alerts_viewer_web/components/layouts/app.html.heex
+++ b/lib/alerts_viewer_web/components/layouts/app.html.heex
@@ -7,8 +7,8 @@
     </div>
     <nav class="flex items-center gap-4">
       <.link patch={~p"/alerts-to-close"}>Alerts to Close</.link>
-      <.link patch={~p"/alerts"}>Alerts</.link>
-      <.link patch={~p"/bus"}>Bus</.link>
+      <.link :if={@internal_pages_flag} patch={~p"/alerts"}>Alerts</.link>
+      <.link :if={@internal_pages_flag} patch={~p"/bus"}>Bus</.link>
       <.link patch={~p"/open-delay-alerts"}>Open Delay Alerts</.link>
     </nav>
   </div>

--- a/lib/alerts_viewer_web/components/layouts/app.html.heex
+++ b/lib/alerts_viewer_web/components/layouts/app.html.heex
@@ -7,8 +7,8 @@
     </div>
     <nav class="flex items-center gap-4">
       <.link patch={~p"/alerts-to-close"}>Alerts to Close</.link>
-      <.link :if={@internal_pages_flag} patch={~p"/alerts"}>Alerts</.link>
-      <.link :if={@internal_pages_flag} patch={~p"/bus"}>Bus</.link>
+      <.link :if={@show_internal_pages_flag} patch={~p"/alerts"}>Alerts</.link>
+      <.link :if={@show_internal_pages_flag} patch={~p"/bus"}>Bus</.link>
       <.link patch={~p"/open-delay-alerts"}>Open Delay Alerts</.link>
     </nav>
   </div>

--- a/lib/alerts_viewer_web/controllers/page_html/home.html.heex
+++ b/lib/alerts_viewer_web/controllers/page_html/home.html.heex
@@ -5,10 +5,10 @@
     <li>
       <.link patch={~p"/alerts-to-close"}>Alerts to Close</.link>
     </li>
-    <li>
+    <li :if={@internal_pages_flag}>
       <.link patch={~p"/alerts"}>Alerts</.link>
     </li>
-    <li>
+    <li :if={@internal_pages_flag}>
       <.link patch={~p"/bus"}>Bus</.link>
     </li>
     <li>

--- a/lib/alerts_viewer_web/controllers/page_html/home.html.heex
+++ b/lib/alerts_viewer_web/controllers/page_html/home.html.heex
@@ -5,10 +5,10 @@
     <li>
       <.link patch={~p"/alerts-to-close"}>Alerts to Close</.link>
     </li>
-    <li :if={@internal_pages_flag}>
+    <li :if={@show_internal_pages_flag}>
       <.link patch={~p"/alerts"}>Alerts</.link>
     </li>
-    <li :if={@internal_pages_flag}>
+    <li :if={@show_internal_pages_flag}>
       <.link patch={~p"/bus"}>Bus</.link>
     </li>
     <li>

--- a/lib/alerts_viewer_web/live/put_flags_in_assigns_hook.ex
+++ b/lib/alerts_viewer_web/live/put_flags_in_assigns_hook.ex
@@ -1,0 +1,24 @@
+defmodule AlertsViewerWeb.PutFlagsInAssignsHook do
+  @moduledoc """
+    Grabs Laboratory flags from session and makes them available as assigns
+  """
+
+  import Phoenix.Component
+
+  def on_mount(:default, _params, session, socket) do
+    flags = Application.get_env(:laboratory, :features) |> Enum.map(fn {key, _, _} -> key end)
+
+    socket =
+      Enum.reduce(flags, socket, fn flag, socket ->
+        value =
+          case session_value = session[Atom.to_string(flag)] do
+            nil -> nil
+            _ -> session_value
+          end
+
+        socket |> assign(flag, value)
+      end)
+
+    {:cont, socket}
+  end
+end

--- a/lib/alerts_viewer_web/put_flags_in_session_plug.ex
+++ b/lib/alerts_viewer_web/put_flags_in_session_plug.ex
@@ -1,0 +1,30 @@
+defmodule AlertsViewerWeb.Plug.PutFlagsInSessionPlug do
+  @moduledoc """
+    Reads in Laboratory flags and makes them available on live view sessions.
+    Necessary because cookies are hard to access from LiveView.
+  """
+  import Plug.Conn
+
+  def init(_) do
+    %{}
+  end
+
+  def call(conn, _opts) do
+    conn = fetch_cookies(conn)
+    flags = Application.get_env(:laboratory, :features) |> Enum.map(fn {key, _, _} -> key end)
+
+    Enum.reduce(flags, conn, fn flag, conn ->
+      value =
+        case conn.cookies[Atom.to_string(flag)] do
+          nil -> false
+          "true" -> true
+        end
+
+      conn
+      # Makes it available in LiveView
+      |> put_session(flag, value)
+      # Makes it available in traditional controllers
+      |> assign(flag, value)
+    end)
+  end
+end

--- a/lib/alerts_viewer_web/router.ex
+++ b/lib/alerts_viewer_web/router.ex
@@ -1,10 +1,14 @@
 defmodule AlertsViewerWeb.Router do
   use AlertsViewerWeb, :router
 
+  pipeline :get_flags do
+    plug AlertsViewerWeb.Plug.PutFlagsInSessionPlug
+  end
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
-    plug AlertsViewerWeb.Plug.PutFlagsInSessionPlug
+    plug(:get_flags)
     plug(:fetch_live_flash)
     plug(:put_root_layout, {AlertsViewerWeb.Layouts, :root})
     plug(:protect_from_forgery)
@@ -20,6 +24,7 @@ defmodule AlertsViewerWeb.Router do
   end
 
   scope "/_flags", Laboratory do
+    pipe_through(:browser)
     forward "/", Router
   end
 

--- a/lib/alerts_viewer_web/router.ex
+++ b/lib/alerts_viewer_web/router.ex
@@ -4,6 +4,7 @@ defmodule AlertsViewerWeb.Router do
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
+    plug AlertsViewerWeb.Plug.PutFlagsInSessionPlug
     plug(:fetch_live_flash)
     plug(:put_root_layout, {AlertsViewerWeb.Layouts, :root})
     plug(:protect_from_forgery)
@@ -18,17 +19,23 @@ defmodule AlertsViewerWeb.Router do
     get("/_health", HealthController, :index)
   end
 
-  scope "/", AlertsViewerWeb do
-    pipe_through(:browser)
+  scope "/_flags", Laboratory do
+    forward "/", Router
+  end
 
-    get("/", PageController, :home)
+  live_session :default, on_mount: AlertsViewerWeb.PutFlagsInAssignsHook do
+    scope "/", AlertsViewerWeb do
+      pipe_through(:browser)
 
-    live("/alerts", AlertsLive, :index)
-    live("/alerts/:id", AlertsLive, :show)
+      get("/", PageController, :home)
 
-    live("/bus", BusLive)
-    live("/alerts-to-close", AlertsToCloseLive)
-    live("/open-delay-alerts", OpenDelayAlertsLive)
+      live("/alerts", AlertsLive, :index)
+      live("/alerts/:id", AlertsLive, :show)
+
+      live("/bus", BusLive)
+      live("/alerts-to-close", AlertsToCloseLive)
+      live("/open-delay-alerts", OpenDelayAlertsLive)
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,10 @@ defmodule AlertsViewer.MixProject do
         "coveralls.html": :test,
         vcr: :test
       ],
-      deps: deps()
+      deps: deps(),
+      dialyzer: [
+        plt_add_apps: [:laboratory]
+      ]
     ]
   end
 
@@ -25,6 +28,7 @@ defmodule AlertsViewer.MixProject do
   def application do
     [
       mod: {AlertsViewer.Application, []},
+      included_applications: [:laboratory],
       extra_applications: [:logger, :runtime_tools]
     ]
   end
@@ -67,7 +71,8 @@ defmodule AlertsViewer.MixProject do
       {:statistics, "~> 0.6.2",
        git: "https://github.com/msharp/elixir-statistics", ref: "897851f"},
       {:csv, "~> 3.0"},
-      {:exvcr, "~> 0.14.3", only: :test}
+      {:exvcr, "~> 0.14.3", only: :test},
+      {:laboratory, github: "paulswartz/laboratory", ref: "cookie_opts"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -28,6 +28,7 @@
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm", "fc3499fed7a726995aa659143a248534adc754ebd16ccd437cd93b649a95091f"},
+  "laboratory": {:git, "https://github.com/paulswartz/laboratory.git", "24adbe2cb18d8368e140ab5e13c8f5b75adea742", [ref: "cookie_opts"]},
   "meck": {:hex, :meck, "0.9.2", "85ccbab053f1db86c7ca240e9fc718170ee5bda03810a6292b5306bf31bae5f5", [:rebar3], [], "hexpm", "81344f561357dc40a8344afa53767c32669153355b626ea9fcbc8da6b3045826"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},

--- a/test/alerts_viewer_web/live/alerts_to_close_live_test.exs
+++ b/test/alerts_viewer_web/live/alerts_to_close_live_test.exs
@@ -124,4 +124,33 @@ defmodule AlertsViewerWeb.AlertsToCloseLiveTest do
       assert recommended_closure.id == "5"
     end
   end
+
+  describe "Laboratory flags" do
+    setup do
+      start_supervised({Registry, keys: :duplicate, name: :alerts_subscriptions_registry})
+      {:ok, _pid} = AlertsPubSub.start_link(subscribe_fn: fn _, _ -> :ok end)
+      start_supervised({Registry, keys: :duplicate, name: :route_stats_subscriptions_registry})
+      {:ok, _pid} = RouteStatsPubSub.start_link()
+      start_supervised({Registry, keys: :duplicate, name: :trip_updates_subscriptions_registry})
+      {:ok, _pid} = TripUpdatesPubSub.start_link()
+      reassign_env(:alerts_viewer, :api_url, "http://localhost:#{54_292}")
+
+      {:ok, %{}}
+    end
+
+    test "Extra links not shown if internal_pages flag is not set", %{conn: conn} do
+      use_cassette "routes", custom: true, clear_mock: true, match_requests_on: [:query] do
+        {:ok, _view, html} = live(conn, "/alerts-to-close")
+        refute html =~ ~r/a href="\/alerts"/
+      end
+    end
+
+    test "Extra links hown if internal_pages flag isset", %{conn: conn} do
+      use_cassette "routes", custom: true, clear_mock: true, match_requests_on: [:query] do
+        conn = conn |> put_resp_cookie("show_internal_pages_flag", "true")
+        {:ok, _view, html} = live(conn, "/alerts-to-close")
+        assert html =~ ~r/a href="\/alerts"/
+      end
+    end
+  end
 end

--- a/test/alerts_viewer_web/live/alerts_to_close_live_test.exs
+++ b/test/alerts_viewer_web/live/alerts_to_close_live_test.exs
@@ -145,7 +145,7 @@ defmodule AlertsViewerWeb.AlertsToCloseLiveTest do
       end
     end
 
-    test "Extra links hown if internal_pages flag isset", %{conn: conn} do
+    test "Extra links shown if internal_pages flag is set", %{conn: conn} do
       use_cassette "routes", custom: true, clear_mock: true, match_requests_on: [:query] do
         conn = conn |> put_resp_cookie("show_internal_pages_flag", "true")
         {:ok, _view, html} = live(conn, "/alerts-to-close")

--- a/test/alerts_viewer_web/put_flags_in_session_plug_test.exs
+++ b/test/alerts_viewer_web/put_flags_in_session_plug_test.exs
@@ -1,0 +1,31 @@
+defmodule AlertsViewerWeb.PutFlagsInSessionPlugTest do
+  use AlertsViewerWeb.ConnCase
+  use Plug.Test
+
+  describe "Put Flags in Session Plug" do
+    test "flag is false if it has not been set", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> fetch_session()
+        |> bypass_through(AlertsViewerWeb.Router, :get_flags)
+        |> get("/")
+
+      assert conn.assigns.test_flag == false
+      assert conn.private.plug_session["test_flag"] == false
+    end
+
+    test "flag is true if it has been set", %{conn: conn} do
+      conn =
+        conn
+        |> put_resp_cookie("test_flag", "true")
+        |> Plug.Test.init_test_session(%{})
+        |> fetch_session()
+        |> bypass_through(AlertsViewerWeb.Router, :get_flags)
+        |> get("/")
+
+      assert conn.assigns.test_flag == true
+      assert conn.private.plug_session["test_flag"] == true
+    end
+  end
+end


### PR DESCRIPTION
Introduces the Laboratory library, and puts Alerts and Bus link behind a flag. They can be re-enabled by visiting the `/_flags` route and refreshing.

I had to add some extra things to get it to work. Laboratory works via cookies, which are only available on the `conn`. If the flag is "on", there is a cookie with the flag name set to "true". If it's "off", there is no cookie with that name at all. Only the root layout in LiveView can access the `conn` assign. The solution was to make a Plug that iterates through the flags set in config, checks the `conn` for their presence, and adds them to the `session` with a value of `true` if they're found and `false` if they're not.

Then, to make it so you don't have to worry about individually adding flags to session assigns, I added an `on_mount` hook that gets the flags from config and their values from the session, and adds them to `socket.assigns`.  So the workflow for adding a new flag `foo` should be just to add it to the list of Laboratory features in `config.exs`, and it should be automatically available as the assign `@foo` in your LiveView pages.

Asana ticket: https://app.asana.com/0/1167196461144361/1205316824418860/f