### PR TITLE
feat: Add Google Tag Manager scripts for analytics

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,8 @@ config :alerts_viewer,
     AlertsViewer.StopRecommendationAlgorithm.HeadwayDeviationComponent,
     AlertsViewer.StopRecommendationAlgorithm.AdherenceComponent
   ],
-  trip_updates_url: {:system, "TRIP_UPDATES_URL"}
+  trip_updates_url: {:system, "TRIP_UPDATES_URL"},
+  google_tag_manager_id: {:system, "GOOGLE_TAG_MANAGER_ID"}
 
 # Configures the endpoint
 config :alerts_viewer, AlertsViewerWeb.Endpoint,

--- a/lib/alerts_viewer/application.ex
+++ b/lib/alerts_viewer/application.ex
@@ -68,7 +68,8 @@ defmodule AlertsViewer.Application do
       :api_key,
       :swiftly_authorization_key,
       :swiftly_realtime_vehicles_url,
-      :trip_updates_url
+      :trip_updates_url,
+      :google_tag_manager_id
     ]
 
     for application_key <- application_keys do

--- a/lib/alerts_viewer_web/components/layouts.ex
+++ b/lib/alerts_viewer_web/components/layouts.ex
@@ -6,4 +6,11 @@ defmodule AlertsViewerWeb.Layouts do
   use AlertsViewerWeb, :html
 
   embed_templates "layouts/*"
+
+  def google_tag_manager_id do
+    case Application.get_env(:alerts_viewer, :google_tag_manager_id, "") do
+      "" -> nil
+      id -> id
+    end
+  end
 end

--- a/lib/alerts_viewer_web/components/layouts/root.html.heex
+++ b/lib/alerts_viewer_web/components/layouts/root.html.heex
@@ -7,11 +7,32 @@
     <.live_title suffix=" · Alerts Viewer">
       <%= assigns[:page_title] || "Alerts Viewer" %>
     </.live_title>
+
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
+    <!-- Google Tag Manager -->
+    <script :if={google_tag_manager_id()}>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','<%= google_tag_manager_id() %>');
+    </script>
+    <!-- End Google Tag Manager -->
   </head>
   <body class="bg-white antialiased">
     <%= @inner_content %>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript :if={google_tag_manager_id()}>
+      <iframe
+        src={"https://www.googletagmanager.com/ns.html?id=#{google_tag_manager_id()}"}
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"
+      >
+      </iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
   </body>
 </html>

--- a/lib/alerts_viewer_web/components/layouts/root.html.heex
+++ b/lib/alerts_viewer_web/components/layouts/root.html.heex
@@ -11,20 +11,20 @@
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
-    <!-- Google Tag Manager -->
     <script :if={google_tag_manager_id()}>
+      // Google Tag Manager
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
           new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','<%= google_tag_manager_id() %>');
+      // End Google Tag Manager
     </script>
-    <!-- End Google Tag Manager -->
   </head>
   <body class="bg-white antialiased">
     <%= @inner_content %>
-    <!-- Google Tag Manager (noscript) -->
     <noscript :if={google_tag_manager_id()}>
+      <!-- Google Tag Manager (noscript) -->
       <iframe
         src={"https://www.googletagmanager.com/ns.html?id=#{google_tag_manager_id()}"}
         height="0"
@@ -32,7 +32,7 @@
         style="display:none;visibility:hidden"
       >
       </iframe>
+      <!-- End Google Tag Manager (noscript) -->
     </noscript>
-    <!-- End Google Tag Manager (noscript) -->
   </body>
 </html>


### PR DESCRIPTION
Asana ticket: app portion of [Add Google analytics](https://app.asana.com/0/1204819229687089/1205784855883890)

This follows up on the [infrastructure update](https://github.com/mbta/devops/pull/1299).

Get the GTM ID from an environment variable.

Live now on [dev-orange](https://alerts-viewer-dev-orange.mbtace.com).